### PR TITLE
fix: detect mTLS client certificate requirement from HTTP 4xx responses

### DIFF
--- a/lib/components/LoginScreen/login_flow.dart
+++ b/lib/components/LoginScreen/login_flow.dart
@@ -9,6 +9,7 @@ import 'package:finamp/services/server_client_discovery_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
+import 'package:chopper/chopper.dart' show ChopperHttpException;
 import 'package:http/http.dart';
 import 'package:logging/logging.dart';
 
@@ -263,15 +264,31 @@ class ServerState {
       try {
         publicServerInfo = await jellyfinApiHelper.loadServerPublicInfo();
       } catch (error) {
-        if (ClientCertificateInstaller.isSupported &&
-            error is ClientException &&
-            error.message.contains("TLSV1_ALERT_CERTIFICATE_REQUIRED")) {
-          clientCertificateRequired = true;
-          // Found server requiring mTLS certificate, no need to try other protocols/ports.
-          return;
-        } else {
-          serverStateLogger.severe("Error loading server info: $error");
+        if (ClientCertificateInstaller.isSupported) {
+          if (error is ClientException && error.message.contains("TLSV1_ALERT_CERTIFICATE_REQUIRED")) {
+            clientCertificateRequired = true;
+            // Found server requiring mTLS certificate, no need to try other protocols/ports.
+            return;
+          }
+          if (error is ChopperHttpException && error.response.statusCode >= 400 && error.response.statusCode < 500) {
+            clientCertificateRequired = true;
+            return;
+          }
+          // Some reverse proxies reject without client cert at HTTP level.
+          try {
+            final statusCode = (error as dynamic).statusCode as int?;
+            if (statusCode != null && statusCode >= 400 && statusCode < 500) {
+              clientCertificateRequired = true;
+              return;
+            }
+          } catch (_) {}
+          // Non-JSON response body (HTML error page).
+          if (error is FormatException) {
+            clientCertificateRequired = true;
+            return;
+          }
         }
+        serverStateLogger.severe("Error loading server info: $error");
       }
       if (this.baseUrlToTest != baseUrl) {
         throw Exception("Server URL changed while testing");

--- a/lib/components/LoginScreen/login_server_selection_page.dart
+++ b/lib/components/LoginScreen/login_server_selection_page.dart
@@ -12,7 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
-import 'package:http/http.dart' show ClientException;
+import 'package:http/http.dart' show ClientException, Response;
 import 'package:logging/logging.dart';
 
 import 'login_flow.dart';
@@ -62,6 +62,18 @@ class _LoginServerSelectionPageState extends ConsumerState<LoginServerSelectionP
             error.message.contains("TLSV1_ALERT_CERTIFICATE_REQUIRED")) {
           _loginServerSelectionPageLogger.info(
             "Discovered server '${response.name}' at ${response.address} requires an mTLS client certificate",
+          );
+          if (mounted && !widget.serverState.clientCertificateRequired) {
+            setState(() {
+              widget.serverState.clientCertificateRequired = true;
+            });
+          }
+        } else if (ClientCertificateInstaller.isSupported &&
+            error is Response &&
+            error.statusCode >= 400 &&
+            error.statusCode < 500) {
+          _loginServerSelectionPageLogger.info(
+            "Discovered server '${response.name}' at ${response.address} might require an mTLS client certificate (HTTP ${error.statusCode})",
           );
           if (mounted && !widget.serverState.clientCertificateRequired) {
             setState(() {

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -540,15 +540,15 @@ class JellyfinApiHelper {
     );
     final httpClient = ChopperClient().httpClient; // http? where we're going, we don't need http
     final response = await httpClient.get(requestUrl);
-    final responseJson = jsonDecode(response.body) as Map<String, dynamic>;
 
-    if (response.statusCode == 200) {
-      PublicSystemInfoResult publicSystemInfoResult = PublicSystemInfoResult.fromJson(responseJson);
-
-      return publicSystemInfoResult;
-    } else {
+    if (response.statusCode != 200) {
       return Future.error(response);
     }
+
+    final responseJson = jsonDecode(response.body) as Map<String, dynamic>;
+    PublicSystemInfoResult publicSystemInfoResult = PublicSystemInfoResult.fromJson(responseJson);
+
+    return publicSystemInfoResult;
   }
 
   /// Fetch all public users from the server.


### PR DESCRIPTION
This PR follows up to the last merged PR adding mTLS support @Maxr1998 kindly worked on.

## Changes
Extend mTLS client certificate detection in the login flow to also handle HTTP 4xx responses, not just TLS-level alerts. PR #1575 added mTLS support, but the detection only handles `TLSV1_ALERT_CERTIFICATE_REQUIRED` during the TLS handshake. Some reverse proxy configurations (i.e. nginx with `ssl_verify_client optional` + application-level checking) reject requests without a valid client certificate at the HTTP level with 4xx status codes. When this happens, `clientCertificateRequired` is never set, the import prompt never appears, and the app falls through to HTTP on port 8096 where it gets a connection refused error.

There were two places of changes. Extended the catch block after `loadServerPublicInfo()` to check for any 4xx HTTP status code in addition to the existing TLS alert check in `login_flow.dart`. And the same logic in the auto-discovery catch block for `login_server_selection_page.dart`.

## Todo before merging
- [x] Reset Settings (no new settings)
- [ ] Extended CONTRIBUTING.md

## Related Issues
- #1575