### PR TITLE
Fix music search only returning results for the first typed letter

### DIFF
--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -77,6 +77,10 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
 
   // This function just lets us easily set stuff to the getItems call we want.
   Future<void> _getPage(int pageKey) async {
+    // Capture the term this request is being issued for, so that once the
+    // (slow) response comes back we can tell whether the user has since typed
+    // a different search.
+    final searchTerm = widget.searchTerm?.trim();
     try {
       final sortOrder =
           widget.sortOrder?.toString() ?? SortOrder.ascending.toString();
@@ -105,7 +109,7 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
                         ? "ProductionYear,PremiereDate"
                         : "SortName"),
         sortOrder: sortOrder,
-        searchTerm: widget.searchTerm?.trim(),
+        searchTerm: searchTerm,
         // If this is the genres tab, tell getItems to get genres.
         isGenres: widget.tabContentType == TabContentType.genres,
         filters: widget.isFavourite ? "IsFavorite" : null,
@@ -113,10 +117,26 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
         limit: _pageSize,
       );
 
+      if (!mounted) return;
+
+      // Append the results first. This is important even when the search term
+      // has since changed: the pagination controller coalesces refreshes for
+      // the same page key and won't issue a new request until the current one
+      // completes by appending, so dropping the result without appending would
+      // leave the list stuck on a loading indicator forever.
       if (newItems!.length < _pageSize) {
         _pagingController.appendLastPage(newItems);
       } else {
         _pagingController.appendPage(newItems, pageKey + newItems.length);
+      }
+
+      // If the search term changed while we were awaiting, these results are
+      // stale. Now that the request has completed, a refresh will actually
+      // fetch the current term (which the coalescing prevented earlier).
+      final currentSearch = widget.searchTerm?.trim();
+      if (searchTerm != currentSearch) {
+        _pagingController.refresh();
+        return;
       }
       if (letterToSearch != null) {
         scrollToLetter(letterToSearch);

--- a/lib/screens/music_screen.dart
+++ b/lib/screens/music_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:get_it/get_it.dart';
@@ -31,6 +33,7 @@ class _MusicScreenState extends State<MusicScreen>
   bool _showShuffleFab = false;
   TextEditingController textEditingController = TextEditingController();
   String? searchQuery;
+  Timer? _searchDebounce;
   final _musicScreenLogger = Logger("MusicScreen");
 
   TabController? _tabController;
@@ -39,7 +42,21 @@ class _MusicScreenState extends State<MusicScreen>
   final _finampUserHelper = GetIt.instance<FinampUserHelper>();
   final _jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
 
+  // Debounce search input so we only issue one query once the user pauses
+  // typing, instead of firing (and largely wasting) a network request on every
+  // keystroke.
+  void _onSearchChanged(String value) {
+    _searchDebounce?.cancel();
+    _searchDebounce = Timer(const Duration(milliseconds: 350), () {
+      if (!mounted) return;
+      setState(() {
+        searchQuery = value;
+      });
+    });
+  }
+
   void _stopSearching() {
+    _searchDebounce?.cancel();
     setState(() {
       textEditingController.clear();
       searchQuery = null;
@@ -89,6 +106,7 @@ class _MusicScreenState extends State<MusicScreen>
 
   @override
   void dispose() {
+    _searchDebounce?.cancel();
     _tabController?.dispose();
     super.dispose();
   }
@@ -191,9 +209,7 @@ class _MusicScreenState extends State<MusicScreen>
                       ? TextField(
                           controller: textEditingController,
                           autofocus: true,
-                          onChanged: (value) => setState(() {
-                            searchQuery = value;
-                          }),
+                          onChanged: (value) => _onSearchChanged(value),
                           decoration: InputDecoration(
                             border: InputBorder.none,
                             hintText: MaterialLocalizations.of(context)
@@ -226,10 +242,13 @@ class _MusicScreenState extends State<MusicScreen>
                               Icons.cancel,
                               color: Theme.of(context).colorScheme.onSurface,
                             ),
-                            onPressed: () => setState(() {
-                              textEditingController.clear();
-                              searchQuery = null;
-                            }),
+                            onPressed: () {
+                              _searchDebounce?.cancel();
+                              setState(() {
+                                textEditingController.clear();
+                                searchQuery = null;
+                              });
+                            },
                             tooltip: AppLocalizations.of(context)!.clear,
                           )
                         ]


### PR DESCRIPTION
Typing a query like "Nirvana" in the music search bar returned results for just "N". Every keystroke called PagingController.refresh(), but infinite_scroll_pagination coalesces refreshes for the same page key: while a "page 0" request is in flight it issues no new request. As a result only the first keystroke's term was ever fetched, and its (first-letter) results were all that showed once the slow response arrived.

Debounce the search field so a single query is issued for the final term once the user pauses typing, instead of one request per keystroke.

As a safety net for burst typing (a pause mid-word can still start a request for a partial term while a later refresh gets coalesced away), _getPage now appends the response before checking staleness and, if the term changed while the request was in flight, triggers a refresh so the current term actually gets fetched. Appending first is required: the controller won't issue a new request until the in-flight one completes, so dropping the result would leave the list stuck on a spinner.

Fixes finamp-app/finamp#1729