### PR TITLE
Add optional Jellyfin star ratings

### DIFF
--- a/lib/components/PlayerScreen/track_name_content.dart
+++ b/lib/components/PlayerScreen/track_name_content.dart
@@ -2,6 +2,7 @@ import 'package:finamp/components/AddToPlaylistScreen/add_to_playlist_button.dar
 import 'package:finamp/components/PlayerScreen/album_chip.dart';
 import 'package:finamp/components/PlayerScreen/artist_chip.dart';
 import 'package:finamp/components/PlayerScreen/player_buttons_more.dart';
+import 'package:finamp/components/PlayerScreen/track_rating.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/jellyfin_models.dart' as jellyfin_models;
 import 'package:finamp/screens/player_screen.dart';
@@ -27,6 +28,8 @@ class TrackNameContent extends ConsumerWidget {
     final currentTrack = queue!.currentTrack!;
 
     final jellyfin_models.BaseItemDto trackBaseItemDto = currentTrack.baseItem;
+    final showStarRatings = ref.watch(finampSettingsProvider.showStarRatings);
+    final chipBackgroundColor = IconTheme.of(context).color!.withValues(alpha: 0.1);
 
     Widget getContent(BoxConstraints constraints, double padding) => Column(
       crossAxisAlignment: CrossAxisAlignment.center,
@@ -106,20 +109,26 @@ class TrackNameContent extends ConsumerWidget {
           children: [
             PlayerButtonsMore(item: trackBaseItemDto, queueItem: currentTrack),
             Flexible(
-              child: ArtistChips(
-                baseItem: trackBaseItemDto,
-                backgroundColor: IconTheme.of(context).color!.withOpacity(0.1),
-              ),
+              child: showStarRatings
+                  ? TrackRating(baseItem: trackBaseItemDto)
+                  : ArtistChips(baseItem: trackBaseItemDto, backgroundColor: chipBackgroundColor),
             ),
             AddToPlaylistButton(item: trackBaseItemDto, queueItem: currentTrack),
           ],
         ),
+        if (showStarRatings)
+          Center(
+            child: Container(
+              constraints: const BoxConstraints(maxWidth: 280),
+              child: ArtistChips(baseItem: trackBaseItemDto, backgroundColor: chipBackgroundColor),
+            ),
+          ),
         Center(
           child: Container(
             constraints: const BoxConstraints(maxWidth: 280),
             child: AlbumChips(
               baseItem: trackBaseItemDto,
-              backgroundColor: IconTheme.of(context).color!.withOpacity(0.1),
+              backgroundColor: chipBackgroundColor,
               key: trackBaseItemDto.album == null ? null : ValueKey("${trackBaseItemDto.album}-album"),
             ),
           ),

--- a/lib/components/PlayerScreen/track_rating.dart
+++ b/lib/components/PlayerScreen/track_rating.dart
@@ -1,0 +1,125 @@
+import 'dart:async';
+
+import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/models/jellyfin_models.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:finamp/services/user_rating_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class TrackRating extends ConsumerStatefulWidget {
+  const TrackRating({super.key, required this.baseItem});
+
+  final BaseItemDto baseItem;
+
+  @override
+  ConsumerState<TrackRating> createState() => _TrackRatingState();
+}
+
+class _TrackRatingState extends ConsumerState<TrackRating> {
+  static const _starWidth = 44.0;
+  static const _starCount = 5;
+
+  double? _dragRating;
+
+  double _ratingForPosition(double dx, {required bool allowHalfStars}) {
+    if (dx <= 0) return 0;
+
+    final raw = (dx / _starWidth).clamp(0.0, _starCount.toDouble());
+    final steps = allowHalfStars ? 2.0 : 1.0;
+
+    return ((raw * steps).ceil() / steps).clamp(allowHalfStars ? 0.5 : 1.0, _starCount.toDouble());
+  }
+
+  void _updateDrag(Offset localPosition, {required bool allowHalfStars}) {
+    setState(() {
+      _dragRating = _ratingForPosition(localPosition.dx, allowHalfStars: allowHalfStars);
+    });
+  }
+
+  void _finishDrag() {
+    final rating = _dragRating;
+    if (rating == null) return;
+
+    setState(() => _dragRating = null);
+    unawaited(setUserRating(ref, widget.baseItem, rating == 0 ? null : rating));
+  }
+
+  void _cancelDrag() {
+    if (_dragRating == null) return;
+    setState(() => _dragRating = null);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ratingProvider = userRatingProvider(widget.baseItem);
+    final rating = ref.watch(ratingProvider);
+    final isUpdating = ref.watch(userRatingUpdatingProvider(widget.baseItem.id));
+    final allowHalfStars = ref.watch(finampSettingsProvider.allowHalfStarRatings);
+
+    final storedStars = ratingToStarValue(rating);
+    final selectedStars = _dragRating ?? (allowHalfStars ? storedStars : storedStars.roundToDouble());
+
+    final displayRating = selectedStars % 1 == 0 ? selectedStars.toInt().toString() : selectedStars.toString();
+
+    final l10n = AppLocalizations.of(context)!;
+    final ratingLabel = selectedStars == 0 ? l10n.starRatingNotRated : l10n.starRatingValueLabel(displayRating);
+
+    return Semantics(
+      container: true,
+      label: ratingLabel,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onHorizontalDragStart: isUpdating
+            ? null
+            : (details) => _updateDrag(details.localPosition, allowHalfStars: allowHalfStars),
+        onHorizontalDragUpdate: isUpdating
+            ? null
+            : (details) => _updateDrag(details.localPosition, allowHalfStars: allowHalfStars),
+        onHorizontalDragEnd: isUpdating ? null : (_) => _finishDrag(),
+        onHorizontalDragCancel: isUpdating ? null : _cancelDrag,
+        child: SizedBox(
+          width: _starWidth * _starCount,
+          height: _starWidth,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: List.generate(_starCount, (index) {
+              final stars = index + 1;
+              final remaining = selectedStars - index;
+
+              final icon = remaining >= 1
+                  ? Icons.star_rounded
+                  : remaining >= 0.5
+                  ? Icons.star_half_rounded
+                  : Icons.star_border_rounded;
+
+              final clearsRating = selectedStars == stars;
+              final starLabel = l10n.starRatingValueLabel(stars.toString());
+
+              return Semantics(
+                button: true,
+                enabled: !isUpdating,
+                label: starLabel,
+                selected: clearsRating,
+                excludeSemantics: true,
+                child: SizedBox(
+                  width: _starWidth,
+                  height: _starWidth,
+                  child: IconButton(
+                    padding: EdgeInsets.zero,
+                    tooltip: clearsRating ? l10n.clearStarRating : starLabel,
+                    iconSize: 24,
+                    onPressed: isUpdating
+                        ? null
+                        : () => unawaited(setUserRating(ref, widget.baseItem, clearsRating ? null : stars)),
+                    icon: Icon(icon),
+                  ),
+                ),
+              );
+            }),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3760,5 +3760,39 @@
     "quickSettingsTranscodeLink": "All transcoding settings",
     "quickSettingsLayoutLink": "All layout & theme settings",
     "quickSettingsAllSettingsLink": "All Settings",
-    "quickSettingsNetworkLink": "Configure the local address for your server"
+    "quickSettingsNetworkLink": "Configure the local address for your server",
+    "showStarRatingsTitle": "Show star ratings",
+    "@showStarRatingsTitle": {
+        "description": "Title for the setting that shows personal Jellyfin star ratings in the player."
+    },
+    "showStarRatingsSubtitle": "Show your personal Jellyfin rating in the player, lyrics view, and supported system media controls.",
+    "@showStarRatingsSubtitle": {
+        "description": "Subtitle for the setting that shows personal Jellyfin star ratings."
+    },
+    "allowHalfStarRatingsTitle": "Allow half-star ratings",
+    "@allowHalfStarRatingsTitle": {
+        "description": "Title for the setting that enables half-star rating increments."
+    },
+    "allowHalfStarRatingsSubtitle": "Swipe across the stars to choose ratings in half-star steps.",
+    "@allowHalfStarRatingsSubtitle": {
+        "description": "Subtitle for the setting that enables half-star rating increments."
+    },
+    "starRatingNotRated": "Not rated",
+    "@starRatingNotRated": {
+        "description": "Accessibility label for a track that has no personal star rating."
+    },
+    "starRatingValueLabel": "{rating} of 5 stars",
+    "@starRatingValueLabel": {
+        "description": "Accessibility label and tooltip for a personal star rating.",
+        "placeholders": {
+            "rating": {
+                "type": "String",
+                "example": "4.5"
+            }
+        }
+    },
+    "clearStarRating": "Clear rating",
+    "@clearStarRating": {
+        "description": "Tooltip for clearing the personal star rating of a track."
+    }
 }

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -318,6 +318,8 @@ class DefaultSettings {
   static const useAndroidGainEffect = true;
   static const ClientCertificate? clientCertificate = null;
   static const showQuickActionsBanner = true;
+  static const showStarRatings = false;
+  static const allowHalfStarRatings = false;
 }
 
 @HiveType(typeId: 28)
@@ -466,6 +468,8 @@ class FinampSettings {
     this.clientCertificate = DefaultSettings.clientCertificate,
     this.showQuickActionsBanner = DefaultSettings.showQuickActionsBanner,
     this.perTabContentViewType = DefaultSettings.perTabContentViewType,
+    this.showStarRatings = DefaultSettings.showStarRatings,
+    this.allowHalfStarRatings = DefaultSettings.allowHalfStarRatings,
   });
 
   @HiveField(0, defaultValue: DefaultSettings.isOffline)
@@ -969,6 +973,15 @@ class FinampSettings {
   @HiveField(160, defaultValue: DefaultSettings.perTabContentViewType)
   @SettingsHelperMap("tabContentType")
   Map<ContentType, ContentViewType> perTabContentViewType;
+
+  /// Whether personal Jellyfin star ratings are shown in the player and
+  /// exposed to supported system media controls.
+  @HiveField(161, defaultValue: DefaultSettings.showStarRatings)
+  bool showStarRatings;
+
+  /// Whether the in-app rating control allows half-star increments.
+  @HiveField(162, defaultValue: DefaultSettings.allowHalfStarRatings)
+  bool allowHalfStarRatings;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(
@@ -4468,6 +4481,7 @@ enum FinampQuickActions {
   surpriseMe(true),
   @HiveField(9)
   playSpecificItem(true);
+
   // ID 10 moved upwards for more sensible user-facing ordering
   //TODO support album/artist shuffle (requires queue support)
 

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -463,6 +463,8 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
                 ContentType.genres: ContentViewType.list,
               }
             : (fields[160] as Map).cast<ContentType, ContentViewType>(),
+        showStarRatings: fields[161] == null ? false : fields[161] as bool,
+        allowHalfStarRatings: fields[162] == null ? false : fields[162] as bool,
       )
       ..sortBy = fields[7] as SortBy?
       ..sortOrder = fields[8] as SortOrder?
@@ -486,7 +488,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(149)
+      ..writeByte(151)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -784,7 +786,11 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(159)
       ..write(obj.showQuickActionsBanner)
       ..writeByte(160)
-      ..write(obj.perTabContentViewType);
+      ..write(obj.perTabContentViewType)
+      ..writeByte(161)
+      ..write(obj.showStarRatings)
+      ..writeByte(162)
+      ..write(obj.allowHalfStarRatings);
   }
 
   @override

--- a/lib/screens/player_settings_screen.dart
+++ b/lib/screens/player_settings_screen.dart
@@ -64,6 +64,8 @@ class PlayerSettingsScreen extends ConsumerWidget {
                 FinampSetters.setFeatureChipsConfiguration(oldFeatureChipsConfig.copyWith(features: oldFeatures));
               },
             ),
+          ShowStarRatingsToggle(),
+          if (ref.watch(finampSettingsProvider.showStarRatings)) AllowHalfStarRatingsToggle(),
           ShowAlbumReleaseDateOnPlayerScreenToggle(),
           PlayerScreenMinimumCoverPaddingEditor(),
           SuppressPlayerPaddingSwitch(),
@@ -71,6 +73,35 @@ class PlayerSettingsScreen extends ConsumerWidget {
           HidePlayerBottomActionsSwitch(),
         ],
       ),
+    );
+  }
+}
+
+class ShowStarRatingsToggle extends ConsumerWidget {
+  const ShowStarRatingsToggle({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile.adaptive(
+      title: Text(AppLocalizations.of(context)!.showStarRatingsTitle),
+      subtitle: Text(AppLocalizations.of(context)!.showStarRatingsSubtitle),
+      value: ref.watch(finampSettingsProvider.showStarRatings),
+      onChanged: FinampSetters.setShowStarRatings,
+    );
+  }
+}
+
+class AllowHalfStarRatingsToggle extends ConsumerWidget {
+  const AllowHalfStarRatingsToggle({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile.adaptive(
+      contentPadding: const EdgeInsets.only(left: 32, right: 16),
+      title: Text(AppLocalizations.of(context)!.allowHalfStarRatingsTitle),
+      subtitle: Text(AppLocalizations.of(context)!.allowHalfStarRatingsSubtitle),
+      value: ref.watch(finampSettingsProvider.allowHalfStarRatings),
+      onChanged: FinampSetters.setAllowHalfStarRatings,
     );
   }
 }

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -76,6 +76,8 @@ class FinampSettingsHelper {
     finampSettingsTemp.suppressPlayerPadding = DefaultSettings.suppressPlayerPadding;
     finampSettingsTemp.prioritizeCoverFactor = DefaultSettings.prioritizeCoverFactor;
     finampSettingsTemp.hidePlayerBottomActions = DefaultSettings.hidePlayerBottomActions;
+    finampSettingsTemp.showStarRatings = DefaultSettings.showStarRatings;
+    finampSettingsTemp.allowHalfStarRatings = DefaultSettings.allowHalfStarRatings;
 
     Hive.box<FinampSettings>("FinampSettings").put("FinampSettings", finampSettingsTemp);
   }

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1317,6 +1317,22 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setShowStarRatings(bool newShowStarRatings) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.showStarRatings = newShowStarRatings;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
+  static void setAllowHalfStarRatings(bool newAllowHalfStarRatings) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.allowHalfStarRatings = newAllowHalfStarRatings;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1763,6 +1779,11 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
   ) => finampSettingsProvider.select(
     (value) => value.requireValue.perTabContentViewType[tabContentType],
   );
+  ProviderListenable<bool> get showStarRatings => finampSettingsProvider.select(
+    (value) => value.requireValue.showStarRatings,
+  );
+  ProviderListenable<bool> get allowHalfStarRatings => finampSettingsProvider
+      .select((value) => value.requireValue.allowHalfStarRatings);
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(
         (value) => value.requireValue.downloadTranscodingProfile,

--- a/lib/services/jellyfin_api.chopper.dart
+++ b/lib/services/jellyfin_api.chopper.dart
@@ -834,6 +834,34 @@ final class _$JellyfinApi extends JellyfinApi {
   }
 
   @override
+  Future<dynamic> setUserRating({
+    required BaseItemId itemId,
+    required Map<String, dynamic> userData,
+  }) async {
+    final Uri $url = Uri.parse('/UserItems/${itemId}/UserData');
+    final $body = userData;
+    final Request $request = Request('POST', $url, client.baseUrl, body: $body);
+    final Response $response = await client.send<dynamic, dynamic>(
+      $request,
+      requestConverter: JsonConverter.requestFactory,
+      responseConverter: JsonConverter.responseFactory,
+    );
+    return $response.bodyOrThrow;
+  }
+
+  @override
+  Future<dynamic> clearUserRating({required BaseItemId itemId}) async {
+    final Uri $url = Uri.parse('/UserItems/${itemId}/Rating');
+    final Request $request = Request('DELETE', $url, client.baseUrl);
+    final Response $response = await client.send<dynamic, dynamic>(
+      $request,
+      requestConverter: JsonConverter.requestFactory,
+      responseConverter: JsonConverter.responseFactory,
+    );
+    return $response.bodyOrThrow;
+  }
+
+  @override
   Future<dynamic> getLyrics({required BaseItemId itemId}) async {
     final Uri $url = Uri.parse('/Audio/${itemId}/Lyrics');
     final Request $request = Request('GET', $url, client.baseUrl);

--- a/lib/services/jellyfin_api.dart
+++ b/lib/services/jellyfin_api.dart
@@ -558,6 +558,16 @@ abstract class JellyfinApi extends ChopperService {
     @Path() required BaseItemId itemId,
   });
 
+  /// Updates personal user data for an item.
+  @FactoryConverter(request: JsonConverter.requestFactory, response: JsonConverter.responseFactory)
+  @POST(path: "/UserItems/{itemId}/UserData")
+  Future<dynamic> setUserRating({@Path() required BaseItemId itemId, @Body() required Map<String, dynamic> userData});
+
+  /// Clears the personal numeric rating for an item.
+  @FactoryConverter(request: JsonConverter.requestFactory, response: JsonConverter.responseFactory)
+  @DELETE(path: "/UserItems/{itemId}/Rating")
+  Future<dynamic> clearUserRating({@Path() required BaseItemId itemId});
+
   /// Requests lyrics for a track.
   @FactoryConverter(request: JsonConverter.requestFactory, response: JsonConverter.responseFactory)
   @Get(path: "/Audio/{itemId}/Lyrics")

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -969,6 +969,28 @@ class JellyfinApiHelper {
     return UserItemDataDto.fromJson(response as Map<String, dynamic>);
   }
 
+  /// Sets the current user's personal Jellyfin rating for an item.
+  Future<UserItemDataDto> setUserRating(BaseItemId itemId, double rating) async {
+    assert(_verifyCallable());
+
+    if (rating < 0 || rating > 10) {
+      throw ArgumentError.value(rating, "rating", "Jellyfin ratings must be between 0 and 10");
+    }
+
+    final response = await jellyfinApi.setUserRating(itemId: itemId, userData: <String, dynamic>{"Rating": rating});
+
+    return UserItemDataDto.fromJson(response as Map<String, dynamic>);
+  }
+
+  /// Removes the current user's personal numeric rating for an item.
+  Future<UserItemDataDto> clearUserRating(BaseItemId itemId) async {
+    assert(_verifyCallable());
+
+    final response = await jellyfinApi.clearUserRating(itemId: itemId);
+
+    return UserItemDataDto.fromJson(response as Map<String, dynamic>);
+  }
+
   void addArtistToMixBuilderList(BaseItemDto item) {
     selectedMixArtists.add(item);
   }

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -12,8 +12,10 @@ import 'package:finamp/models/jellyfin_models.dart' as jellyfin_models;
 import 'package:finamp/services/current_track_metadata_provider.dart';
 import 'package:finamp/services/favorite_provider.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
+import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:finamp/services/playback_history_service.dart';
 import 'package:finamp/services/queue_service.dart';
+import 'package:finamp/services/user_rating_provider.dart';
 import 'package:finamp/services/radio_service_helper.dart' as RadioServiceHelper;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -300,6 +302,11 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
 
   MusicPlayerBackgroundTask() {
     _audioServiceBackgroundTaskLogger.info("Starting audio service");
+
+    GetIt.instance<ProviderContainer>().listen<bool>(
+      finampSettingsProvider.showStarRatings,
+      (_, _) => _handleStarRatingSettingChanged(),
+    );
 
     if (Platform.isWindows || Platform.isLinux) {
       _audioServiceBackgroundTaskLogger.info("Initializing media-kit for Windows/Linux");
@@ -1157,6 +1164,27 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
     return playbackState.add(event);
   }
 
+  void _handleStarRatingSettingChanged() {
+    final currentMediaItem = mediaItem.valueOrNull;
+
+    if (currentMediaItem?.extras?["itemJson"] != null) {
+      final currentItem = jellyfin_models.BaseItemDto.fromJson(
+        currentMediaItem!.extras!["itemJson"] as Map<String, dynamic>,
+      );
+      final currentRating = GetIt.instance<ProviderContainer>().read(userRatingProvider(currentItem));
+
+      mediaItem.add(
+        currentMediaItem.copyWith(
+          rating: FinampSettingsHelper.finampSettings.showStarRatings
+              ? Rating.newHeartRating((currentRating ?? 0) >= 10.0)
+              : null,
+        ),
+      );
+    }
+
+    unawaited(refreshPlaybackStateAndMediaNotification());
+  }
+
   // triggers when skipping to specific item in android auto queue
   @override
   Future<void> skipToQueueItem(int index) async {
@@ -1294,9 +1322,15 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
         if (FinampSettingsHelper.finampSettings.showStopButtonOnMediaNotification)
           MediaControl.stop.copyWith(androidIcon: "drawable/baseline_stop_24"),
       ],
-      systemActions: FinampSettingsHelper.finampSettings.showSeekControlsOnMediaNotification
-          ? const {MediaAction.seek, MediaAction.seekForward, MediaAction.seekBackward}
-          : {},
+      systemActions: {
+        if (FinampSettingsHelper.finampSettings.showSeekControlsOnMediaNotification) ...{
+          MediaAction.seek,
+          MediaAction.seekForward,
+          MediaAction.seekBackward,
+        },
+        if (FinampSettingsHelper.finampSettings.showStarRatings && !FinampSettingsHelper.finampSettings.isOffline)
+          MediaAction.setRating,
+      },
       androidCompactActionIndices: const [0, 1, 2],
       processingState: const {
         ProcessingState.idle: AudioProcessingState.idle,
@@ -1486,12 +1520,44 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
     bool isFavorite = currentItem.userData?.isFavorite ?? false;
     switch (rating.getRatingStyle()) {
       case RatingStyle.heart:
-        if (rating.hasHeart() && !isFavorite) {
-          // add favorite
-          await toggleFavoriteStatusOfCurrentTrack();
-        } else if (!rating.hasHeart() && isFavorite) {
-          // remove favorite
-          await toggleFavoriteStatusOfCurrentTrack();
+        if (!FinampSettingsHelper.finampSettings.showStarRatings) {
+          if (rating.hasHeart() && !isFavorite) {
+            await toggleFavoriteStatusOfCurrentTrack();
+          } else if (!rating.hasHeart() && isFavorite) {
+            await toggleFavoriteStatusOfCurrentTrack();
+          }
+          break;
+        }
+
+        if (FinampSettingsHelper.finampSettings.isOffline) {
+          return;
+        }
+
+        final container = GetIt.instance<ProviderContainer>();
+        final provider = userRatingProvider(currentItem);
+        final previousRating = container.read(provider);
+
+        try {
+          final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
+          final userData = rating.hasHeart()
+              ? await jellyfinApiHelper.setUserRating(currentItem.id, 10.0)
+              : await jellyfinApiHelper.clearUserRating(currentItem.id);
+
+          container.read(provider.notifier).state = userData.rating;
+
+          final currentMediaItem = mediaItem.valueOrNull;
+          if (currentMediaItem != null) {
+            mediaItem.add(currentMediaItem.copyWith(rating: Rating.newHeartRating((userData.rating ?? 0) >= 10.0)));
+          }
+
+          _audioServiceBackgroundTaskLogger.fine("Updated personal rating from system control: ${userData.rating}");
+        } catch (error, stackTrace) {
+          container.read(provider.notifier).state = previousRating;
+          _audioServiceBackgroundTaskLogger.warning(
+            "Failed to update personal rating from system control",
+            error,
+            stackTrace,
+          );
         }
         break;
       case RatingStyle.thumbUpDown:

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -21,6 +21,7 @@ import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:finamp/services/music_player_background_task.dart';
 import 'package:finamp/services/playback_history_service.dart';
 import 'package:finamp/services/radio_service_helper.dart';
+import 'package:finamp/services/user_rating_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
@@ -181,6 +182,7 @@ class QueueService {
   }
 
   ProviderSubscription<AlbumImageInfo>? _latestAlbumImage;
+  ProviderSubscription<double?>? _currentRatingSubscription;
 
   void _buildQueueFromNativePlayerQueue({bool logUpdate = true, int? indexOverride}) {
     final playbackHistoryService = GetIt.instance<PlaybackHistoryService>();
@@ -280,8 +282,28 @@ class QueueService {
     refreshQueueStream();
     _currentTrackStream.add(_currentTrack);
     var currentMediaItem = _currentTrack?.item;
+
+    _currentRatingSubscription?.close();
+    _currentRatingSubscription = null;
+
     if (currentMediaItem != null) {
       final item = jellyfin_models.BaseItemDto.fromJson(currentMediaItem.extras!["itemJson"] as Map<String, dynamic>);
+
+      void updateRating(double? rating) {
+        currentMediaItem = currentMediaItem?.copyWith(
+          rating: FinampSettingsHelper.finampSettings.showStarRatings
+              ? Rating.newHeartRating((rating ?? 0) >= 10.0)
+              : null,
+        );
+        _audioHandler.mediaItem.add(currentMediaItem);
+      }
+
+      _currentRatingSubscription = _providers.listen<double?>(
+        userRatingProvider(item),
+        (_, rating) => updateRating(rating),
+        fireImmediately: true,
+      );
+
       final artRequest = AlbumImageRequest(item: item);
 
       void updateMediaItem(AlbumImageInfo latest, bool force) async {
@@ -1504,6 +1526,9 @@ class QueueService {
       album: item.album,
       artist: item.artists?.sortedBy((e) => e).join(", ") ?? item.albumArtist,
       title: item.name ?? "unknown",
+      rating: FinampSettingsHelper.finampSettings.showStarRatings
+          ? Rating.newHeartRating((item.userData?.rating ?? 0) >= 10.0)
+          : null,
       extras: {
         //!!! this ID has to be consistent across the transcoding URL and the playback reporting status, otherwise the server won't show that we're transcoding
         "playSessionId": uuid.v4(),

--- a/lib/services/user_rating_provider.dart
+++ b/lib/services/user_rating_provider.dart
@@ -1,0 +1,55 @@
+import 'package:finamp/components/global_snackbar.dart';
+import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/models/jellyfin_models.dart';
+import 'package:finamp/services/feedback_helper.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:finamp/services/jellyfin_api_helper.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:get_it/get_it.dart';
+
+final userRatingProvider = StateProvider.autoDispose.family<double?, BaseItemDto>((ref, item) => item.userData?.rating);
+
+final userRatingUpdatingProvider = StateProvider.autoDispose.family<bool, BaseItemId>((ref, itemId) => false);
+
+double ratingToStarValue(double? rating) {
+  if (rating == null) return 0;
+  return (rating / 2).clamp(0.0, 5.0);
+}
+
+int ratingToStars(double? rating) => ratingToStarValue(rating).round();
+
+double starsToRating(num stars) => stars.clamp(0.5, 5.0).toDouble() * 2.0;
+
+Future<void> setUserRating(WidgetRef ref, BaseItemDto item, num? stars) async {
+  if (FinampSettingsHelper.finampSettings.isOffline) {
+    FeedbackHelper.feedback(FeedbackType.error);
+    GlobalSnackbar.message((context) => AppLocalizations.of(context)!.notAvailableInOfflineMode);
+    return;
+  }
+
+  final updatingProvider = userRatingUpdatingProvider(item.id);
+  if (ref.read(updatingProvider)) return;
+
+  final provider = userRatingProvider(item);
+  final oldRating = ref.read(provider);
+  final newRating = stars == null || stars <= 0 ? null : starsToRating(stars);
+
+  ref.read(updatingProvider.notifier).state = true;
+  ref.read(provider.notifier).state = newRating;
+
+  try {
+    final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
+    final userData = newRating == null
+        ? await jellyfinApiHelper.clearUserRating(item.id)
+        : await jellyfinApiHelper.setUserRating(item.id, newRating);
+
+    ref.read(provider.notifier).state = userData.rating;
+    FeedbackHelper.feedback(FeedbackType.selection);
+  } catch (error) {
+    ref.read(provider.notifier).state = oldRating;
+    FeedbackHelper.feedback(FeedbackType.error);
+    GlobalSnackbar.error(error);
+  } finally {
+    ref.read(updatingProvider.notifier).state = false;
+  }
+}

--- a/test/services/user_rating_provider_test.dart
+++ b/test/services/user_rating_provider_test.dart
@@ -1,0 +1,67 @@
+import 'package:finamp/services/user_rating_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ratingToStars', () {
+    test('maps Jellyfin 0-10 ratings to five stars', () {
+      expect(ratingToStars(null), 0);
+      expect(ratingToStars(0), 0);
+      expect(ratingToStars(2), 1);
+      expect(ratingToStars(4), 2);
+      expect(ratingToStars(6), 3);
+      expect(ratingToStars(8), 4);
+      expect(ratingToStars(10), 5);
+    });
+
+    test('rounds intermediate Jellyfin ratings to the nearest star', () {
+      expect(ratingToStars(1), 1);
+      expect(ratingToStars(3), 2);
+      expect(ratingToStars(5), 3);
+      expect(ratingToStars(7), 4);
+      expect(ratingToStars(9), 5);
+    });
+
+    test('clamps out-of-range input defensively', () {
+      expect(ratingToStars(-1), 0);
+      expect(ratingToStars(11), 5);
+    });
+  });
+
+  group('ratingToStarValue', () {
+    test('preserves half-star values from Jellyfin', () {
+      expect(ratingToStarValue(1), 0.5);
+      expect(ratingToStarValue(3), 1.5);
+      expect(ratingToStarValue(5), 2.5);
+      expect(ratingToStarValue(7), 3.5);
+      expect(ratingToStarValue(9), 4.5);
+    });
+
+    test('clamps out-of-range values', () {
+      expect(ratingToStarValue(-1), 0.0);
+      expect(ratingToStarValue(11), 5.0);
+    });
+  });
+
+  group('starsToRating', () {
+    test('maps five stars to Jellyfin 0-10 rating values', () {
+      expect(starsToRating(1), 2.0);
+      expect(starsToRating(2), 4.0);
+      expect(starsToRating(3), 6.0);
+      expect(starsToRating(4), 8.0);
+      expect(starsToRating(5), 10.0);
+    });
+
+    test('maps half stars to odd Jellyfin rating values', () {
+      expect(starsToRating(0.5), 1.0);
+      expect(starsToRating(1.5), 3.0);
+      expect(starsToRating(2.5), 5.0);
+      expect(starsToRating(3.5), 7.0);
+      expect(starsToRating(4.5), 9.0);
+    });
+
+    test('clamps invalid star counts defensively', () {
+      expect(starsToRating(0), 1.0);
+      expect(starsToRating(6), 10.0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

This adds optional personal Jellyfin star ratings to Finamp using Jellyfin's existing `UserData.Rating` field.

The feature is disabled by default and is intentionally separate from Jellyfin's existing favorite/heart state.

## Why?

Finamp already exposes Jellyfin favorites well, but a favorite is inherently binary: a track is either a favorite or it is not.

Jellyfin also stores a personal numeric rating for each item (`UserData.Rating`, 0–10). That represents a different piece of user data:

- **Favorite / heart:** "I want this in my favorites."
- **Rating:** "How much do I like this track?"

Using only the favorite flag loses that distinction. A binary heart cannot express preference strength without creating additional playlists or tags.

For larger music libraries, numeric ratings are useful for gradually curating a collection and distinguishing between tracks that are merely worth keeping, tracks a user actively likes, favorites, and exceptional tracks they may want to surface more often.

Jellyfin already has a dedicated per-user numeric rating field for this purpose, so this PR exposes existing server functionality rather than introducing a separate Finamp-only rating model or overloading `IsFavorite`.

First-class personal numeric ratings also appear to be relatively uncommon among current Jellyfin-focused mobile music clients. Rating systems exist elsewhere in the Jellyfin ecosystem, but exposing Jellyfin's own per-user numeric rating directly in a dedicated mobile music player is still unusual.

This also makes ratings useful beyond the immediate player UI: they provide structured personal library metadata that can later be used for filtering, recommendations, or rule-based/smart playlists.

The broader value of preserving personal listening metadata as input for future smart-playlist rules has already come up in Finamp discussion:
https://github.com/finamp-app/finamp/issues/194

This PR does **not** replace favorites. `IsFavorite` and `UserData.Rating` remain independent and useful for different purposes.

## User experience

When enabled in Player Settings:

- a five-star control is shown in the existing player action area
- the same control is available in the portrait lyrics view through `TrackNameContent`
- tapping a star sets the personal rating
- tapping the currently selected star clears the rating
- an optional setting enables half-star ratings
- half-star values can be selected by swiping across the control
- favorites continue to work exactly as before

The setting is off by default, so the existing player layout and behavior remain unchanged unless the user explicitly enables ratings.

## Jellyfin mapping

Jellyfin stores personal ratings on a 0–10 scale. Finamp maps this to the UI as:

- 0.5 stars → 1
- 1 star → 2
- 2 stars → 4
- 3 stars → 6
- 4 stars → 8
- 5 stars → 10

Ratings are written using Jellyfin's user-data endpoint:

`POST /UserItems/{itemId}/UserData`

Clearing a rating uses:

`DELETE /UserItems/{itemId}/Rating`

This deliberately does **not** use Jellyfin's like/dislike endpoint and does not modify `IsFavorite`.

## Implementation

The implementation follows the existing Finamp architecture:

- settings are part of `FinampSettings` and persisted through Hive
- generated settings providers/setters are used
- Jellyfin endpoints are defined in `jellyfin_api.dart`
- calls go through `JellyfinApiHelper`
- UI state uses Riverpod
- updates are optimistic and roll back on API failure
- writes are disabled in offline mode
- all new user-facing strings use Finamp's localization system
- interactive star targets are 44×44 with accessibility labels/tooltips
- conversion behavior has unit tests
- existing system-heart behavior is preserved when star ratings are disabled

## System media controls

The PR also exposes the existing `MediaAction.setRating` abstraction when ratings are enabled.

For iOS, the intended lock-screen representation is a single heart-style feedback control:

- inactive → set the personal rating to 5 stars / Jellyfin rating 10
- active → clear the personal rating

This is only the system-control representation; it does not turn the Jellyfin favorite state into a rating.

When star ratings are disabled, the existing heart/favorite behavior remains unchanged.

The Finamp implementation contains no custom iOS command-channel workaround. Full iOS lock-screen support depends on the corresponding Darwin implementation in `audio_service`.

## Validation

Validated with:

- `build_runner`
- `flutter gen-l10n`
- `flutter analyze`
- rating conversion unit tests
- debug build on a physical iPhone
- release build on a physical iPhone

The feature was tested with existing Jellyfin numeric ratings as well as setting, changing and clearing ratings from Finamp.

The branch is based on the current `redesign` branch and squashed to one feature commit.

This PR remains a draft until the `audio_service` dependency is ready for upstream review.

## Development note

This feature was developed with assistance from AI tools for code review, implementation support and iteration. The resulting code was manually reviewed and tested, including validation on a physical device.