### PR TITLE
Add "Advanced" login options screen and move mTLS setup there

### DIFF
--- a/lib/components/LoginScreen/login_flow.dart
+++ b/lib/components/LoginScreen/login_flow.dart
@@ -267,7 +267,7 @@ class ServerState {
           // Found server requiring mTLS certificate, no need to try other protocols/ports.
           return;
         } else {
-          serverStateLogger.severe("Error loading server info: $error");
+          serverStateLogger.severe("Couldn't reach server at $baseUrlToTest (HTTPS): $error");
         }
       }
       if (this.baseUrlToTest != baseUrl) {
@@ -282,7 +282,7 @@ class ServerState {
         try {
           publicServerInfo = await jellyfinApiHelper.loadServerPublicInfo();
         } catch (error) {
-          serverStateLogger.severe("Error loading server info: $error");
+          serverStateLogger.severe("Couldn't reach server at $baseUrlToTest (HTTP): $error");
         }
       }
       if (this.baseUrlToTest != baseUrl) {
@@ -297,7 +297,7 @@ class ServerState {
         try {
           publicServerInfo = await jellyfinApiHelper.loadServerPublicInfo();
         } catch (error) {
-          serverStateLogger.severe("Error loading server info: $error");
+          serverStateLogger.severe("Couldn't reach server at $baseUrlToTest (default port): $error");
         }
       }
       if (this.baseUrlToTest != baseUrl) {

--- a/lib/components/LoginScreen/login_flow.dart
+++ b/lib/components/LoginScreen/login_flow.dart
@@ -9,7 +9,6 @@ import 'package:finamp/services/server_client_discovery_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
-import 'package:http/http.dart';
 import 'package:logging/logging.dart';
 
 import 'login_authentication_page.dart';
@@ -263,9 +262,7 @@ class ServerState {
       try {
         publicServerInfo = await jellyfinApiHelper.loadServerPublicInfo();
       } catch (error) {
-        if (ClientCertificateInstaller.isSupported &&
-            error is ClientException &&
-            error.message.contains("TLSV1_ALERT_CERTIFICATE_REQUIRED")) {
+        if (await ClientCertificateInstaller.isCertificateRequiredError(error, Uri.parse(baseUrlToTest))) {
           clientCertificateRequired = true;
           // Found server requiring mTLS certificate, no need to try other protocols/ports.
           return;

--- a/lib/components/LoginScreen/login_server_selection_page.dart
+++ b/lib/components/LoginScreen/login_server_selection_page.dart
@@ -66,7 +66,7 @@ class _LoginServerSelectionPageState extends ConsumerState<LoginServerSelectionP
           }
         } else {
           _loginServerSelectionPageLogger.severe(
-            "Failed to load public server info for discovered server '${response.name}' at ${response.address}: $error",
+            "Couldn't fetch public server info from '${response.name}' at ${response.address}: $error",
           );
         }
         return;

--- a/lib/components/LoginScreen/login_server_selection_page.dart
+++ b/lib/components/LoginScreen/login_server_selection_page.dart
@@ -11,7 +11,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
-import 'package:http/http.dart' show ClientException;
 import 'package:logging/logging.dart';
 
 import 'login_flow.dart';
@@ -56,9 +55,7 @@ class _LoginServerSelectionPageState extends ConsumerState<LoginServerSelectionP
       try {
         serverInfo = await jellyfinApiHelper.loadCustomServerPublicInfo(serverUrl);
       } catch (error) {
-        if (ClientCertificateInstaller.isSupported &&
-            error is ClientException &&
-            error.message.contains("TLSV1_ALERT_CERTIFICATE_REQUIRED")) {
+        if (await ClientCertificateInstaller.isCertificateRequiredError(error, serverUrl)) {
           _loginServerSelectionPageLogger.info(
             "Discovered server '${response.name}' at ${response.address} requires an mTLS client certificate",
           );
@@ -168,10 +165,15 @@ class _LoginServerSelectionPageState extends ConsumerState<LoginServerSelectionP
                         child: ListTile(
                           leading: const Icon(TablerIcons.alert_triangle),
                           title: Text(AppLocalizations.of(context)!.clientCertificateRequired),
-                          onTap: () => Navigator.of(
-                            context,
-                            rootNavigator: true,
-                          ).pushNamed(AdvancedLoginOptionsScreen.routeName),
+                          subtitle: ClientCertificateInstaller.isSupported
+                              ? null
+                              : Text(AppLocalizations.of(context)!.clientCertificatesUnsupported),
+                          onTap: ClientCertificateInstaller.isSupported
+                              ? () => Navigator.of(
+                                  context,
+                                  rootNavigator: true,
+                                ).pushNamed(AdvancedLoginOptionsScreen.routeName)
+                              : null,
                           shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(12.0))),
                         ),
                       ),

--- a/lib/components/LoginScreen/login_server_selection_page.dart
+++ b/lib/components/LoginScreen/login_server_selection_page.dart
@@ -1,9 +1,8 @@
-import 'package:finamp/components/Buttons/cta_medium.dart';
 import 'package:finamp/components/Buttons/simple_button.dart';
 import 'package:finamp/components/finamp_icon.dart';
 import 'package:finamp/l10n/app_localizations.dart';
-import 'package:finamp/menus/client_certificate_authentication_menu.dart';
 import 'package:finamp/models/jellyfin_models.dart';
+import 'package:finamp/screens/advanced_login_options_screen.dart';
 import 'package:finamp/services/client_certificate_installer.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
@@ -111,6 +110,14 @@ class _LoginServerSelectionPageState extends ConsumerState<LoginServerSelectionP
     final clientCertificate = ref.watch(finampSettingsProvider.clientCertificate);
     final isClientCertificateInstalled = clientCertificate != null;
 
+    ref.listen(finampSettingsProvider.clientCertificate, (previous, next) {
+      _restartDiscovery();
+      final baseUrl = widget.serverState.baseUrl;
+      if (baseUrl != null) {
+        widget.serverState.onBaseUrlChanged(baseUrl);
+      }
+    });
+
     return SingleChildScrollView(
       padding: const EdgeInsets.symmetric(horizontal: 32.0),
       child: Center(
@@ -154,49 +161,20 @@ class _LoginServerSelectionPageState extends ConsumerState<LoginServerSelectionP
                         },
                       ),
                     ),
-                  if (isClientCertificateInstalled)
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 12.0),
-                      child: CTAMedium(
-                        text: AppLocalizations.of(context)!.clientCertificateInstalled,
-                        icon: TablerIcons.certificate,
-                        onPressed: () => showClientCertificateMenu(context: context),
-                        minWidth: 0,
+                  if (widget.serverState.clientCertificateRequired && !isClientCertificateInstalled)
+                    Align(
+                      alignment: Alignment.center,
+                      child: IntrinsicWidth(
+                        child: ListTile(
+                          leading: const Icon(TablerIcons.alert_triangle),
+                          title: Text(AppLocalizations.of(context)!.clientCertificateRequired),
+                          onTap: () => Navigator.of(
+                            context,
+                            rootNavigator: true,
+                          ).pushNamed(AdvancedLoginOptionsScreen.routeName),
+                          shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(12.0))),
+                        ),
                       ),
-                    )
-                  else if (widget.serverState.clientCertificateRequired)
-                    Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
-                          child: Text(
-                            AppLocalizations.of(context)!.clientCertificateRequired,
-                            style: Theme.of(context).textTheme.bodyLarge,
-                          ),
-                        ),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            CTAMedium(
-                              text: AppLocalizations.of(context)!.importClientCertificate,
-                              icon: TablerIcons.certificate,
-                              onPressed: () => showClientCertificateMenu(
-                                context: context,
-                                onImported: () {
-                                  _restartDiscovery();
-                                  final baseUrl = widget.serverState.baseUrl;
-                                  if (baseUrl != null) {
-                                    widget.serverState.onBaseUrlChanged(baseUrl);
-                                  }
-                                },
-                              ),
-                              minWidth: 0,
-                            ),
-                          ],
-                        ),
-                      ],
                     ),
                   if (widget.serverState.baseUrlToTest != null && widget.serverState.manualServer == null)
                     Padding(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3620,11 +3620,11 @@
     "@advanced": {
         "description": "Label for the button on the login screen that opens the advanced options screen, and the title of that screen."
     },
-    "clientCertificate": "mTLS (SSL) Client Certificate",
+    "clientCertificate": "Client Certificate (mTLS)",
     "@clientCertificate": {
         "description": "Title for the setting that allows managing SSL client certificates used for authentication"
     },
-    "clientCertificateUnavailable": "No certificate set up, client authentication disabled",
+    "clientCertificateUnavailable": "No certificate set up, additional client authentication disabled",
     "@clientCertificateUnavailable": {
         "description": "Message shown when the user has no SSL client certificate available to use."
     },
@@ -3632,7 +3632,7 @@
     "@clientCertificateInstalled": {
         "description": "Message shown when the user has successfully installed an SSL client certificate."
     },
-    "clientCertificateDescription": "A TLS client certificate (.p12 or .pfx) is used to authenticate this device with your Jellyfin server. Only required if your server is configured for mutual TLS.",
+    "clientCertificateDescription": "A TLS client certificate (.p12 or .pfx) is used to additionally authenticate this device with your Jellyfin server. Only required if your server is configured for mutual TLS.",
     "@clientCertificateDescription": {
         "description": "Explanatory text in the client certificate settings menu describing what a client certificate is used for"
     },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3632,6 +3632,10 @@
     "@clientCertificateInstalled": {
         "description": "Message shown when the user has successfully installed an SSL client certificate."
     },
+    "clientCertificatesUnsupported": "Client certificates are not supported on this platform",
+    "@clientCertificatesUnsupported": {
+        "description": "Message shown when client certificates are not supported on the user's current platform."
+    },
     "clientCertificateDescription": "A TLS client certificate (.p12 or .pfx) is used to additionally authenticate this device with your Jellyfin server. Only required if your server is configured for mutual TLS.",
     "@clientCertificateDescription": {
         "description": "Explanatory text in the client certificate settings menu describing what a client certificate is used for"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3616,6 +3616,10 @@
             }
         }
     },
+    "advanced": "Advanced",
+    "@advanced": {
+        "description": "Label for the button on the login screen that opens the advanced options screen, and the title of that screen."
+    },
     "clientCertificate": "mTLS (SSL) Client Certificate",
     "@clientCertificate": {
         "description": "Title for the setting that allows managing SSL client certificates used for authentication"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:finamp/models/jellyfin_models.dart';
 import 'package:finamp/models/locale_adapter.dart';
 import 'package:finamp/models/music_models.dart';
 import 'package:finamp/screens/accessibility_settings_screen.dart';
+import 'package:finamp/screens/advanced_login_options_screen.dart';
 import 'package:finamp/screens/album_settings_screen.dart';
 import 'package:finamp/screens/artist_settings_screen.dart';
 import 'package:finamp/screens/content_view_type_settings_screen.dart';
@@ -967,6 +968,7 @@ class FinampApp extends ConsumerWidget {
       routes: {
         SplashScreen.routeName: (context) => const SplashScreen(),
         LoginScreen.routeName: (context) => const LoginScreen(),
+        AdvancedLoginOptionsScreen.routeName: (context) => const AdvancedLoginOptionsScreen(),
         ViewSelector.routeName: (context) => const ViewSelector(),
         MusicScreen.routeName: (context) => const MusicScreen(),
         AlbumScreen.routeName: (context) => const AlbumScreen(),

--- a/lib/menus/client_certificate_authentication_menu.dart
+++ b/lib/menus/client_certificate_authentication_menu.dart
@@ -14,7 +14,7 @@ import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 
 const clientCertificateAuthenticationRouteName = "/client-certificate-authentication-menu";
 
-Future<void> showClientCertificateMenu({required BuildContext context, VoidCallback? onImported}) async {
+Future<void> showClientCertificateMenu({required BuildContext context}) async {
   await showThemedBottomSheet(
     context: context,
     routeName: clientCertificateAuthenticationRouteName,
@@ -26,7 +26,7 @@ Future<void> showClientCertificateMenu({required BuildContext context, VoidCallb
           header: const _ClientCertificateMenuHeader(),
           sliver: MenuMask(
             height: const MenuMaskHeight(44.0),
-            child: SliverToBoxAdapter(child: _ClientCertificateMenuContent(onImported: onImported)),
+            child: SliverToBoxAdapter(child: _ClientCertificateMenuContent()),
           ),
         ),
       ];
@@ -54,9 +54,7 @@ class _ClientCertificateMenuHeader extends StatelessWidget {
 }
 
 class _ClientCertificateMenuContent extends ConsumerStatefulWidget {
-  const _ClientCertificateMenuContent({this.onImported});
-
-  final VoidCallback? onImported;
+  const _ClientCertificateMenuContent();
 
   @override
   ConsumerState<_ClientCertificateMenuContent> createState() => _ClientCertificateMenuContentState();
@@ -85,7 +83,6 @@ class _ClientCertificateMenuContentState extends ConsumerState<_ClientCertificat
       await _clientCertificateInstaller.installClientCertificate();
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.clientCertificateImportSuccess)));
-        widget.onImported?.call();
         Navigator.of(context).pop();
       }
     } catch (_) {

--- a/lib/screens/advanced_login_options_screen.dart
+++ b/lib/screens/advanced_login_options_screen.dart
@@ -21,17 +21,19 @@ class AdvancedLoginOptionsScreen extends ConsumerWidget {
       body: ListView(
         padding: const EdgeInsets.only(bottom: 200.0),
         children: [
-          if (ClientCertificateInstaller.isSupported)
-            ListTile(
-              leading: Icon(TablerIcons.certificate),
-              title: Text(AppLocalizations.of(context)!.clientCertificate),
-              subtitle: Text(
-                ref.watch(finampSettingsProvider.clientCertificate) != null
-                    ? AppLocalizations.of(context)!.clientCertificateInstalled
-                    : AppLocalizations.of(context)!.clientCertificateUnavailable,
-              ),
-              onTap: () => showClientCertificateMenu(context: context),
+          ListTile(
+            leading: Icon(TablerIcons.certificate),
+            title: Text(AppLocalizations.of(context)!.clientCertificate),
+            subtitle: Text(
+              !ClientCertificateInstaller.isSupported
+                  ? AppLocalizations.of(context)!.clientCertificatesUnsupported
+                  : ref.watch(finampSettingsProvider.clientCertificate) != null
+                  ? AppLocalizations.of(context)!.clientCertificateInstalled
+                  : AppLocalizations.of(context)!.clientCertificateUnavailable,
             ),
+            enabled: ClientCertificateInstaller.isSupported,
+            onTap: () => showClientCertificateMenu(context: context),
+          ),
           ListTile(
             leading: const Icon(TablerIcons.accessible),
             title: Text(AppLocalizations.of(context)!.accessibility),

--- a/lib/screens/advanced_login_options_screen.dart
+++ b/lib/screens/advanced_login_options_screen.dart
@@ -1,0 +1,49 @@
+import 'package:finamp/components/finamp_app_bar_back_button.dart';
+import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/menus/client_certificate_authentication_menu.dart';
+import 'package:finamp/screens/accessibility_settings_screen.dart';
+import 'package:finamp/screens/logs_screen.dart';
+import 'package:finamp/services/client_certificate_installer.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
+
+class AdvancedLoginOptionsScreen extends ConsumerWidget {
+  const AdvancedLoginOptionsScreen({super.key});
+
+  static const routeName = "/login/advanced";
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: Text(AppLocalizations.of(context)!.advanced), leading: FinampAppBarBackButton()),
+      body: ListView(
+        padding: const EdgeInsets.only(bottom: 200.0),
+        children: [
+          if (ClientCertificateInstaller.isSupported)
+            ListTile(
+              leading: Icon(TablerIcons.certificate),
+              title: Text(AppLocalizations.of(context)!.clientCertificate),
+              subtitle: Text(
+                ref.watch(finampSettingsProvider.clientCertificate) != null
+                    ? AppLocalizations.of(context)!.clientCertificateInstalled
+                    : AppLocalizations.of(context)!.clientCertificateUnavailable,
+              ),
+              onTap: () => showClientCertificateMenu(context: context),
+            ),
+          ListTile(
+            leading: const Icon(TablerIcons.accessible),
+            title: Text(AppLocalizations.of(context)!.accessibility),
+            onTap: () => Navigator.of(context).pushNamed(AccessibilitySettingsScreen.routeName),
+          ),
+          ListTile(
+            leading: const Icon(TablerIcons.file_text),
+            title: Text(AppLocalizations.of(context)!.viewLogs),
+            onTap: () => Navigator.of(context).pushNamed(LogsScreen.routeName),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,7 +1,7 @@
 import 'package:finamp/components/Buttons/simple_button.dart';
 import 'package:finamp/components/LoginScreen/login_flow.dart';
+import 'package:finamp/screens/advanced_login_options_screen.dart';
 import 'package:finamp/screens/language_selection_screen.dart';
-import 'package:finamp/screens/logs_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:finamp/l10n/app_localizations.dart';
@@ -41,9 +41,9 @@ class _LoginAuxillaryOptions extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             SimpleButton(
-              text: AppLocalizations.of(context)!.viewLogs,
-              icon: TablerIcons.file_text,
-              onPressed: () => Navigator.of(context).pushNamed(LogsScreen.routeName),
+              text: AppLocalizations.of(context)!.advanced,
+              icon: TablerIcons.settings,
+              onPressed: () => Navigator.of(context).pushNamed(AdvancedLoginOptionsScreen.routeName),
             ),
             SimpleButton(
               text: AppLocalizations.of(context)!.changeLanguage,

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -23,14 +23,14 @@ class LoginScreen extends StatelessWidget {
       child: const Scaffold(
         resizeToAvoidBottomInset: true,
         body: SafeArea(child: LoginFlow()),
-        bottomNavigationBar: _LoginAuxillaryOptions(),
+        bottomNavigationBar: _LoginAuxiliaryOptions(),
       ),
     );
   }
 }
 
-class _LoginAuxillaryOptions extends StatelessWidget {
-  const _LoginAuxillaryOptions();
+class _LoginAuxiliaryOptions extends StatelessWidget {
+  const _LoginAuxiliaryOptions();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,10 +1,10 @@
 import 'package:finamp/components/Buttons/simple_button.dart';
 import 'package:finamp/components/LoginScreen/login_flow.dart';
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/screens/advanced_login_options_screen.dart';
 import 'package:finamp/screens/language_selection_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 
 class LoginScreen extends StatelessWidget {
   const LoginScreen({super.key});
@@ -36,7 +36,7 @@ class _LoginAuxillaryOptions extends StatelessWidget {
   Widget build(BuildContext context) {
     return SafeArea(
       child: Padding(
-        padding: const EdgeInsets.only(left: 20.0, right: 20.0, bottom: 12.0),
+        padding: EdgeInsets.only(left: 20.0, right: 20.0, bottom: MediaQuery.viewInsetsOf(context).bottom + 12.0),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -222,17 +222,19 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             title: Text(AppLocalizations.of(context)!.quickConnectAuthorizationMenuButtonTitle),
             onTap: () => showQuickConnectAuthorizationMenu(context: context),
           ),
-          if (ClientCertificateInstaller.isSupported)
-            ListTile(
-              leading: Icon(TablerIcons.certificate),
-              title: Text(AppLocalizations.of(context)!.clientCertificate),
-              subtitle: Text(
-                ref.watch(finampSettingsProvider.clientCertificate) != null
-                    ? AppLocalizations.of(context)!.clientCertificateInstalled
-                    : AppLocalizations.of(context)!.clientCertificateUnavailable,
-              ),
-              onTap: () => showClientCertificateMenu(context: context),
+          ListTile(
+            leading: Icon(TablerIcons.certificate),
+            title: Text(AppLocalizations.of(context)!.clientCertificate),
+            subtitle: Text(
+              !ClientCertificateInstaller.isSupported
+                  ? AppLocalizations.of(context)!.clientCertificatesUnsupported
+                  : ref.watch(finampSettingsProvider.clientCertificate) != null
+                  ? AppLocalizations.of(context)!.clientCertificateInstalled
+                  : AppLocalizations.of(context)!.clientCertificateUnavailable,
             ),
+            enabled: ClientCertificateInstaller.isSupported,
+            onTap: () => showClientCertificateMenu(context: context),
+          ),
           const LogoutListTile(),
         ],
       ),

--- a/lib/services/client_certificate_installer.dart
+++ b/lib/services/client_certificate_installer.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
+import 'package:http/http.dart' show ClientException;
 import 'package:logging/logging.dart';
 
 import 'finamp_settings_helper.dart';
@@ -13,6 +14,66 @@ class ClientCertificateInstaller {
 
   static final _logger = Logger('ClientCertificateInstaller');
   static const _channel = MethodChannel('com.unicornsonlsd.finamp/client_certificate');
+
+  static const _certificateRequiredAlert = "TLSV1_ALERT_CERTIFICATE_REQUIRED";
+
+  /// OsError codes for EPIPE and ECONNRESET on Linux and macOS, and WSAECONNABORTED and WSAECONNRESET on Windows
+  static const _writeFailureCodes = {32, 54, 104, 10053, 10054};
+
+  /// Checks whether [error], thrown while connecting to [serverUrl],
+  /// indicates that the server requires an mTLS client certificate.
+  ///
+  /// In the best case, the server's CERTIFICATE_REQUIRED alert shows up in the error message.
+  ///
+  /// However, with TLS 1.3, the client may already have started writing the HTTP request,
+  /// which may fail first and mask the certificate error by a broken pipe.
+  /// Older TLS 1.2 servers don't report a dedicated alert and just abort the handshake instead.
+  ///
+  /// In those unspecific cases, we probe the server for certificate errors without writing any data,
+  /// in which case the issue should be reported cleanly.
+  static Future<bool> isCertificateRequiredError(Object error, Uri serverUrl) async {
+    if (error is ClientException && error.message.contains(_certificateRequiredAlert)) {
+      return true;
+    }
+    if (error is TlsException && (error.osError?.message ?? error.message).contains(_certificateRequiredAlert)) {
+      return true;
+    }
+    // Actual SocketExceptions only occur before a (HTTP) request is in flight (connection refused, DNS failures, ...),
+    // so we can filter by errno here and skip probing servers that are simply unreachable.
+    if (error is SocketException) {
+      return _writeFailureCodes.contains(error.osError?.errorCode) && await _probeCertificateRequired(serverUrl);
+    }
+    if (error is TlsException || error is ClientException || error is HttpException) {
+      return _probeCertificateRequired(serverUrl);
+    }
+    return false;
+  }
+
+  /// Connects to [url] and checks for the server's TLS alert without sending a request,
+  /// so the "certificate required" alert can't be masked by a failed write.
+  static Future<bool> _probeCertificateRequired(Uri url) async {
+    if (url.scheme != "https") {
+      return false;
+    }
+    Socket? socket;
+    try {
+      socket = await SecureSocket.connect(
+        url.host,
+        url.port,
+        // Accepting any server certificate is fine here, no data is sent over the connection
+        onBadCertificate: (_) => true,
+        timeout: const Duration(seconds: 3),
+      );
+      await socket.drain<void>().timeout(const Duration(seconds: 3));
+    } on TlsException catch (e) {
+      return (e.osError?.message ?? e.message).contains(_certificateRequiredAlert);
+    } catch (_) {
+      return false;
+    } finally {
+      socket?.destroy();
+    }
+    return false;
+  }
 
   /// Installs the configured [ClientCertificate] in the whole app, if supported and available:
   /// - into the [SecurityContext.defaultContext] used by Dart's HttpClient


### PR DESCRIPTION
## Changes
The previous "Client certificate required" alert & setup button is replaced with a new "Advanced" screen, where you can also set up mTLS if Finamp doesn't detect the server using it.
The alert remains, but opens the advanced settings instead of directly prompting you to pick a certificate.

<img width="200" alt="image" src="https://github.com/user-attachments/assets/9080ad58-7cf1-4e3d-a5e2-07f4f1be0ab1" /> <img width="200" alt="image" src="https://github.com/user-attachments/assets/566dbf4c-6a27-453b-ad97-956a4be2f03c" />

This also tweaks the strings a bit to clarify that mTLS is optional and not required to have a secure connection ("authentication" → "additional authentication").
I also fixed the bottom controls getting overlapped by the hardware keyboard pop-up, please let me know if I should move that to a separate PR.

## Related Issues
Related to and supersedes #1684.