### PR TITLE
Install mTLS certificate to background_downloader on desktop

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -149,6 +149,8 @@ Future<void> main(List<String> args, {bool integrationTesting = false, bool logi
     _migrateDeviceId();
     await _migrateThemeModeLocale();
     _mainLog.info("Completed applicable migrations");
+    // Initialize FileDownloader singleton with persistent storage backend
+    FileDownloader(persistentStorage: IsarPersistentStorage());
     await _trustAndroidUserCerts();
     await ClientCertificateInstaller().installClientCertificate();
     _mainLog.info("Installed client certificate");
@@ -243,7 +245,7 @@ Future<void> _setupDownloadsHelper() async {
   await Future.wait(
     FinampSettingsHelper.finampSettings.downloadLocationsMap.values.map((element) => element.updateCurrentPath()),
   );
-  final fileDownloader = FileDownloader(persistentStorage: IsarPersistentStorage());
+  final fileDownloader = FileDownloader();
   await fileDownloader.ready;
   WidgetsFlutterBinding.ensureInitialized();
   // There is additional FileDownloader setup inside downloadsService constructor

--- a/lib/services/client_certificate_installer.dart
+++ b/lib/services/client_certificate_installer.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:background_downloader/background_downloader.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
@@ -112,6 +113,14 @@ class ClientCertificateInstaller {
         _logger.warning('Failed to install client certificate in Android SSL context: $e');
       }
     }
+
+    // Install certificate into background_downloader singleton
+    await FileDownloader().configure(
+      desktopConfig: (
+        Config.mTLS,
+        MTLSConfig(certificateBytes: cert.data, privateKeyBytes: cert.data, password: cert.password),
+      ),
+    );
   }
 
   /// Installs the given [cert] into [context].
@@ -138,5 +147,7 @@ class ClientCertificateInstaller {
         _logger.warning('Failed to clear client certificate from Android SSL context: $e');
       }
     }
+
+    await FileDownloader().configure(desktopConfig: (Config.mTLS, false));
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -141,10 +141,10 @@ packages:
     dependency: "direct main"
     description:
       name: background_downloader
-      sha256: d27fcaf94f738032f1e6db098230799bf31ae7bf184f173fc9a752fcdae75c0e
+      sha256: ae55e127f87397b372578fc9474568b879fa78326103c342e00160558d08e527
       url: "https://pub.dev"
     source: hosted
-    version: "9.5.6"
+    version: "9.5.9"
   balanced_text:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  background_downloader: ^9.2.3
+  background_downloader: ^9.5.9
   json_annotation: ^4.8.1
   chopper: ^8.0.0
   get_it: ^8.2.0


### PR DESCRIPTION
## Changes
Also install the client certificate into background_downloader's SecurityContext, required on desktop platforms for downloading when mTLS is enabled.

## Related Issues
- #1578