### PR TITLE
Feature/ios now playing widget pr

### DIFF
--- a/ios/FinampWidget/FinampWidget.entitlements
+++ b/ios/FinampWidget/FinampWidget.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>$(FINAMP_WIDGET_APP_GROUP)</string>
+    </array>
+</dict>
+</plist>

--- a/ios/FinampWidget/FinampWidget.swift
+++ b/ios/FinampWidget/FinampWidget.swift
@@ -163,6 +163,7 @@ private struct RatingOrFavoriteView: View {
     let compact: Bool
 
     var body: some View {
+#if compiler(>=6.4)
         if #available(iOS 27.0, *) {
             if state.showStarRatings {
                 StarRatingView(state: state, compact: compact)
@@ -176,13 +177,21 @@ private struct RatingOrFavoriteView: View {
                 .accessibilityLabel(state.isFavorite ? "Remove favorite" : "Add favorite")
             }
         } else {
-            if state.showStarRatings {
-                StarDisplayView(rating: state.starRating, compact: compact)
-            } else {
-                Image(systemName: state.isFavorite ? "heart.fill" : "heart")
-                    .font(compact ? .body : .title3)
-                    .foregroundStyle(.secondary)
-            }
+            readOnlyContent
+        }
+#else
+        readOnlyContent
+#endif
+    }
+
+    @ViewBuilder
+    private var readOnlyContent: some View {
+        if state.showStarRatings {
+            StarDisplayView(rating: state.starRating, compact: compact)
+        } else {
+            Image(systemName: state.isFavorite ? "heart.fill" : "heart")
+                .font(compact ? .body : .title3)
+                .foregroundStyle(.secondary)
         }
     }
 }
@@ -298,6 +307,7 @@ private struct SmallRatingOrFavoriteView: View {
     let state: FinampWidgetState
 
     var body: some View {
+#if compiler(>=6.4)
         if #available(iOS 27.0, *) {
             if state.showStarRatings {
                 let hasRating = state.starRating != nil
@@ -328,21 +338,29 @@ private struct SmallRatingOrFavoriteView: View {
                 )
             }
         } else {
-            if state.showStarRatings {
-                Image(
-                    systemName: state.starRating == nil
-                        ? "star"
-                        : "star.fill"
-                )
-                .foregroundStyle(.secondary)
-            } else {
-                Image(
-                    systemName: state.isFavorite
-                        ? "heart.fill"
-                        : "heart"
-                )
-                .foregroundStyle(.secondary)
-            }
+            readOnlyContent
+        }
+#else
+        readOnlyContent
+#endif
+    }
+
+    @ViewBuilder
+    private var readOnlyContent: some View {
+        if state.showStarRatings {
+            Image(
+                systemName: state.starRating == nil
+                    ? "star"
+                    : "star.fill"
+            )
+            .foregroundStyle(.secondary)
+        } else {
+            Image(
+                systemName: state.isFavorite
+                    ? "heart.fill"
+                    : "heart"
+            )
+            .foregroundStyle(.secondary)
         }
     }
 }

--- a/ios/FinampWidget/FinampWidget.swift
+++ b/ios/FinampWidget/FinampWidget.swift
@@ -1,0 +1,433 @@
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+struct FinampNowPlayingEntry: TimelineEntry {
+    let date: Date
+    let state: FinampWidgetState
+}
+
+struct FinampNowPlayingProvider: TimelineProvider {
+    func placeholder(in context: Context) -> FinampNowPlayingEntry {
+        .init(date: .now, state: .empty)
+    }
+
+    func getSnapshot(
+        in context: Context,
+        completion: @escaping (FinampNowPlayingEntry) -> Void
+    ) {
+        completion(.init(date: .now, state: .load()))
+    }
+
+    func getTimeline(
+        in context: Context,
+        completion: @escaping (Timeline<FinampNowPlayingEntry>) -> Void
+    ) {
+        let entry = FinampNowPlayingEntry(date: .now, state: .load())
+        completion(Timeline(entries: [entry], policy: .never))
+    }
+}
+
+struct FinampNowPlayingWidget: Widget {
+    let kind = FinampWidgetShared.kind
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: FinampNowPlayingProvider()) { entry in
+            FinampWidgetRootView(state: entry.state)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("Finamp Now Playing")
+        .description("Control playback and rate the current track.")
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+    }
+}
+
+private struct FinampWidgetRootView: View {
+    @Environment(\.widgetFamily) private var family
+    let state: FinampWidgetState
+
+    var body: some View {
+        switch family {
+        case .systemSmall:
+            SmallWidgetView(state: state)
+        case .systemMedium:
+            MediumWidgetView(state: state)
+        case .systemLarge:
+            LargeWidgetView(state: state)
+        default:
+            MediumWidgetView(state: state)
+        }
+    }
+}
+
+private struct CoverView: View {
+    let state: FinampWidgetState
+
+    var body: some View {
+        Group {
+            if let image = loadCoverImage() {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                ZStack {
+                    Rectangle().fill(.quaternary)
+                    Image(systemName: "music.note")
+                        .font(.title)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .clipped()
+    }
+
+    private func loadCoverImage() -> UIImage? {
+        guard
+            let container = FinampWidgetShared.containerURL,
+            let itemID = state.itemID
+        else {
+            return nil
+        }
+
+        let url = container
+            .appendingPathComponent("\(FinampWidgetShared.coverFileName)-\(itemID)")
+            .appendingPathExtension("jpg")
+
+        return UIImage(contentsOfFile: url.path)
+    }
+}
+
+private struct TrackText: View {
+    let state: FinampWidgetState
+    let compact: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: compact ? 1 : 3) {
+            Text(state.title)
+                .font(compact ? .caption.bold() : .headline)
+                .lineLimit(1)
+            if !state.artist.isEmpty {
+                Text(state.artist)
+                    .font(compact ? .caption2 : .subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            if !compact && !state.album.isEmpty {
+                Text(state.album)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+        }
+    }
+}
+
+private struct PlaybackButton: View {
+    let state: FinampWidgetState
+
+    var body: some View {
+        Button(intent: TogglePlaybackIntent()) {
+            Image(systemName: state.isPlaying ? "pause.fill" : "play.fill")
+                .font(.headline)
+                .frame(width: 32, height: 32)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(state.isPlaying ? "Pause" : "Play")
+    }
+}
+
+private struct TransportControls: View {
+    let state: FinampWidgetState
+
+    var body: some View {
+        HStack(spacing: 20) {
+            Button(intent: PreviousTrackIntent()) {
+                Image(systemName: "backward.fill")
+            }
+            .accessibilityLabel("Previous track")
+
+            PlaybackButton(state: state)
+
+            Button(intent: NextTrackIntent()) {
+                Image(systemName: "forward.fill")
+            }
+            .accessibilityLabel("Next track")
+        }
+        .buttonStyle(.plain)
+        .font(.headline)
+    }
+}
+
+private struct RatingOrFavoriteView: View {
+    let state: FinampWidgetState
+    let compact: Bool
+
+    var body: some View {
+        if #available(iOS 27.0, *) {
+            if state.showStarRatings {
+                StarRatingView(state: state, compact: compact)
+            } else {
+                Button(intent: ToggleFavoriteIntent()) {
+                    Image(systemName: state.isFavorite ? "heart.fill" : "heart")
+                        .font(compact ? .body : .title3)
+                        .symbolRenderingMode(.hierarchical)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(state.isFavorite ? "Remove favorite" : "Add favorite")
+            }
+        } else {
+            if state.showStarRatings {
+                StarDisplayView(rating: state.starRating, compact: compact)
+            } else {
+                Image(systemName: state.isFavorite ? "heart.fill" : "heart")
+                    .font(compact ? .body : .title3)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+@available(iOS 27.0, *)
+private struct StarRatingView: View {
+    let state: FinampWidgetState
+    let compact: Bool
+
+    var body: some View {
+        HStack(spacing: compact ? 2 : 5) {
+            ForEach(1...5, id: \.self) { star in
+                let selected = (state.starRating ?? 0) >= Double(star)
+                let clears = state.starRating == Double(star)
+
+                if clears {
+                    Button(intent: ClearStarRatingIntent()) {
+                        starImage(selected: selected)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Clear rating")
+                } else {
+                    Button(intent: SetStarRatingIntent(stars: Double(star))) {
+                        starImage(selected: selected)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(star) of 5 stars")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func starImage(selected: Bool) -> some View {
+        Image(systemName: selected ? "star.fill" : "star")
+            .font(compact ? .caption : .body)
+    }
+}
+
+private struct StarDisplayView: View {
+    let rating: Double?
+    let compact: Bool
+
+    var body: some View {
+        HStack(spacing: compact ? 2 : 5) {
+            ForEach(1...5, id: \.self) { star in
+                Image(systemName: (rating ?? 0) >= Double(star) ? "star.fill" : "star")
+                    .font(compact ? .caption : .body)
+            }
+        }
+        .foregroundStyle(.secondary)
+    }
+}
+
+private struct SmallWidgetView: View {
+    let state: FinampWidgetState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(alignment: .top, spacing: 6) {
+                CoverView(state: state)
+                    .aspectRatio(1, contentMode: .fill)
+                    .frame(maxWidth: .infinity)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                SmallRatingOrFavoriteView(state: state)
+                    .frame(width: 24, alignment: .center)
+                    .padding(.top, 2)
+            }
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(state.title)
+                    .font(.caption.bold())
+                    .lineLimit(1)
+
+                if !state.artist.isEmpty {
+                    Text(state.artist)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Spacer(minLength: 0)
+
+            HStack {
+                Button(intent: PreviousTrackIntent()) {
+                    Image(systemName: "backward.fill")
+                        .frame(width: 28, height: 28)
+                }
+                .accessibilityLabel("Previous track")
+
+                Spacer(minLength: 2)
+
+                PlaybackButton(state: state)
+
+                Spacer(minLength: 2)
+
+                Button(intent: NextTrackIntent()) {
+                    Image(systemName: "forward.fill")
+                        .frame(width: 28, height: 28)
+                }
+                .accessibilityLabel("Next track")
+            }
+            .buttonStyle(.plain)
+            .font(.body)
+        }
+    }
+}
+
+private struct SmallRatingOrFavoriteView: View {
+    let state: FinampWidgetState
+
+    var body: some View {
+        if #available(iOS 27.0, *) {
+            if state.showStarRatings {
+                let hasRating = state.starRating != nil
+
+                if hasRating {
+                    Button(intent: ClearStarRatingIntent()) {
+                        Image(systemName: "star.fill")
+                    }
+                    .accessibilityLabel("Clear rating")
+                } else {
+                    Button(intent: SetStarRatingIntent(stars: 5)) {
+                        Image(systemName: "star")
+                    }
+                    .accessibilityLabel("Rate 5 stars")
+                }
+            } else {
+                Button(intent: ToggleFavoriteIntent()) {
+                    Image(
+                        systemName: state.isFavorite
+                            ? "heart.fill"
+                            : "heart"
+                    )
+                }
+                .accessibilityLabel(
+                    state.isFavorite
+                        ? "Remove favorite"
+                        : "Add favorite"
+                )
+            }
+        } else {
+            if state.showStarRatings {
+                Image(
+                    systemName: state.starRating == nil
+                        ? "star"
+                        : "star.fill"
+                )
+                .foregroundStyle(.secondary)
+            } else {
+                Image(
+                    systemName: state.isFavorite
+                        ? "heart.fill"
+                        : "heart"
+                )
+                .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+private struct MediumWidgetView: View {
+    let state: FinampWidgetState
+
+    var body: some View {
+        HStack(spacing: 12) {
+            CoverView(state: state)
+                .aspectRatio(1, contentMode: .fit)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+
+            VStack(alignment: .leading, spacing: 8) {
+                TrackText(state: state, compact: false)
+                Spacer(minLength: 0)
+                TransportControls(state: state)
+                RatingOrFavoriteView(state: state, compact: false)
+            }
+        }
+    }
+}
+
+private struct LargeWidgetView: View {
+    let state: FinampWidgetState
+
+    var body: some View {
+        VStack(spacing: 8) {
+            CoverView(state: state)
+                .frame(width: 170, height: 170)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+
+            VStack(spacing: 2) {
+                Text(state.title)
+                    .font(.title3.bold())
+                    .lineLimit(1)
+
+                if !state.artist.isEmpty {
+                    Text(state.artist)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                if !state.album.isEmpty {
+                    Text(state.album)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+
+                RatingOrFavoriteView(
+                    state: state,
+                    compact: false
+                )
+                .padding(.top, 3)
+            }
+            .frame(maxWidth: .infinity)
+            .multilineTextAlignment(.center)
+
+            Spacer(minLength: 0)
+
+            Divider()
+
+            HStack {
+                Button(intent: PreviousTrackIntent()) {
+                    Image(systemName: "backward.fill")
+                        .frame(width: 42, height: 42)
+                }
+                .accessibilityLabel("Previous track")
+
+                Spacer()
+
+                PlaybackButton(state: state)
+
+                Spacer()
+
+                Button(intent: NextTrackIntent()) {
+                    Image(systemName: "forward.fill")
+                        .frame(width: 42, height: 42)
+                }
+                .accessibilityLabel("Next track")
+            }
+            .buttonStyle(.plain)
+            .font(.title3)
+        }
+    }
+}

--- a/ios/FinampWidget/FinampWidgetBundle.swift
+++ b/ios/FinampWidget/FinampWidgetBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct FinampWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        FinampNowPlayingWidget()
+    }
+}

--- a/ios/FinampWidget/Info.plist
+++ b/ios/FinampWidget/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>FinampWidgetAppGroup</key>
 	<string>$(FINAMP_WIDGET_APP_GROUP)</string>
 	<key>NSExtension</key>

--- a/ios/FinampWidget/Info.plist
+++ b/ios/FinampWidget/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>Finamp</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>FinampWidgetAppGroup</key>
+	<string>$(FINAMP_WIDGET_APP_GROUP)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/ios/FinampWidget/WidgetIntents.swift
+++ b/ios/FinampWidget/WidgetIntents.swift
@@ -1,0 +1,126 @@
+import AppIntents
+import Foundation
+import WidgetKit
+
+enum FinampWidgetAction: String, Codable, Sendable {
+    case togglePlayback
+    case previous
+    case next
+    case toggleFavorite
+    case setRating
+    case clearRating
+}
+
+enum FinampWidgetActionDispatcher {
+    @MainActor
+    static var handler: ((FinampWidgetAction, Double?) async throws -> Void)?
+
+    @MainActor
+    static func perform(
+        _ action: FinampWidgetAction,
+        rating: Double? = nil
+    ) async throws {
+        guard let handler else {
+            throw NSError(
+                domain: "FinampWidget",
+                code: 2,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Widget action handler is unavailable"
+                ]
+            )
+        }
+
+        // The handler returns only after Finamp has completed the action and
+        // persisted one final coherent shared-state snapshot. Reload exactly
+        // once afterwards so WidgetKit cannot keep rendering the previous
+        // timeline when no later artwork/state event happens to trigger one.
+        try await handler(action, rating)
+        WidgetCenter.shared.reloadTimelines(ofKind: FinampWidgetShared.kind)
+    }
+}
+
+@available(iOS 17.0, *)
+struct TogglePlaybackIntent: AudioPlaybackIntent {
+    static let title: LocalizedStringResource = "Play or Pause"
+
+    func perform() async throws -> some IntentResult {
+        try await FinampWidgetActionDispatcher.perform(.togglePlayback)
+        return .result()
+    }
+}
+
+@available(iOS 17.0, *)
+struct PreviousTrackIntent: AudioPlaybackIntent {
+    static let title: LocalizedStringResource = "Previous Track"
+
+    func perform() async throws -> some IntentResult {
+        try await FinampWidgetActionDispatcher.perform(.previous)
+        return .result()
+    }
+}
+
+@available(iOS 17.0, *)
+struct NextTrackIntent: AudioPlaybackIntent {
+    static let title: LocalizedStringResource = "Next Track"
+
+    func perform() async throws -> some IntentResult {
+        try await FinampWidgetActionDispatcher.perform(.next)
+        return .result()
+    }
+}
+
+// iOS 27 introduces explicit process targeting for App Intents.
+// Metadata writes stay in Finamp's main process so the widget extension never
+// owns Jellyfin credentials or a second network stack.
+@available(iOS 27.0, *)
+struct ToggleFavoriteIntent: AppIntent {
+    static let title: LocalizedStringResource = "Toggle Favorite"
+    static var allowedExecutionTargets: IntentExecutionTargets { .main }
+    static var supportedModes: IntentModes { .background }
+
+    func perform() async throws -> some IntentResult {
+        try await FinampWidgetActionDispatcher.perform(.toggleFavorite)
+        return .result()
+    }
+}
+
+@available(iOS 27.0, *)
+struct SetStarRatingIntent: AppIntent {
+    static let title: LocalizedStringResource = "Set Rating"
+    static var allowedExecutionTargets: IntentExecutionTargets { .main }
+    static var supportedModes: IntentModes { .background }
+
+    @Parameter(title: "Stars")
+    var stars: Double
+
+    init() {}
+
+    init(stars: Double) {
+        self.stars = stars
+    }
+
+    func perform() async throws -> some IntentResult {
+        guard (1...5).contains(stars) else {
+            throw NSError(
+                domain: "FinampWidget",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "Rating must be between 1 and 5 stars"]
+            )
+        }
+        try await FinampWidgetActionDispatcher.perform(.setRating, rating: stars)
+        return .result()
+    }
+}
+
+@available(iOS 27.0, *)
+struct ClearStarRatingIntent: AppIntent {
+    static let title: LocalizedStringResource = "Clear Rating"
+    static var allowedExecutionTargets: IntentExecutionTargets { .main }
+    static var supportedModes: IntentModes { .background }
+
+    func perform() async throws -> some IntentResult {
+        try await FinampWidgetActionDispatcher.perform(.clearRating)
+        return .result()
+    }
+}

--- a/ios/FinampWidget/WidgetIntents.swift
+++ b/ios/FinampWidget/WidgetIntents.swift
@@ -76,8 +76,10 @@ struct NextTrackIntent: AudioPlaybackIntent {
 @available(iOS 27.0, *)
 struct ToggleFavoriteIntent: AppIntent {
     static let title: LocalizedStringResource = "Toggle Favorite"
+#if compiler(>=6.4)
     static var allowedExecutionTargets: IntentExecutionTargets { .main }
     static var supportedModes: IntentModes { .background }
+#endif
 
     func perform() async throws -> some IntentResult {
         try await FinampWidgetActionDispatcher.perform(.toggleFavorite)
@@ -88,8 +90,10 @@ struct ToggleFavoriteIntent: AppIntent {
 @available(iOS 27.0, *)
 struct SetStarRatingIntent: AppIntent {
     static let title: LocalizedStringResource = "Set Rating"
+#if compiler(>=6.4)
     static var allowedExecutionTargets: IntentExecutionTargets { .main }
     static var supportedModes: IntentModes { .background }
+#endif
 
     @Parameter(title: "Stars")
     var stars: Double
@@ -116,8 +120,10 @@ struct SetStarRatingIntent: AppIntent {
 @available(iOS 27.0, *)
 struct ClearStarRatingIntent: AppIntent {
     static let title: LocalizedStringResource = "Clear Rating"
+#if compiler(>=6.4)
     static var allowedExecutionTargets: IntentExecutionTargets { .main }
     static var supportedModes: IntentModes { .background }
+#endif
 
     func perform() async throws -> some IntentResult {
         try await FinampWidgetActionDispatcher.perform(.clearRating)

--- a/ios/FinampWidget/WidgetState.swift
+++ b/ios/FinampWidget/WidgetState.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+enum FinampWidgetShared {
+    static let kind = "FinampNowPlayingWidget"
+    static let stateFileName = "now-playing-state.json"
+    static let coverFileName = "now-playing-cover"
+
+    static var appGroupIdentifier: String {
+        if
+            let value = Bundle.main.object(forInfoDictionaryKey: "FinampWidgetAppGroup") as? String,
+            !value.isEmpty
+        {
+            return value
+        }
+
+        let fallbackBundleID = Bundle.main.bundleIdentifier
+            ?? "com.unicornsonlsd.finamp-ios"
+        return "group.\(fallbackBundleID).widget"
+    }
+
+    static var containerURL: URL? {
+        FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: appGroupIdentifier
+        )
+    }
+
+    static var stateURL: URL? {
+        containerURL?.appendingPathComponent(stateFileName)
+    }
+}
+
+struct FinampWidgetState: Codable, Equatable {
+    var itemID: String?
+    var title: String
+    var artist: String
+    var album: String
+    var isPlaying: Bool
+    var showStarRatings: Bool
+    var isFavorite: Bool
+    var starRating: Double?
+    var coverRevision: Int
+
+    static let empty = FinampWidgetState(
+        itemID: nil,
+        title: "Finamp",
+        artist: "",
+        album: "",
+        isPlaying: false,
+        showStarRatings: false,
+        isFavorite: false,
+        starRating: nil,
+        coverRevision: 0
+    )
+
+    static func load() -> FinampWidgetState {
+        guard
+            let stateURL = FinampWidgetShared.stateURL,
+            let data = try? Data(contentsOf: stateURL),
+            let state = try? JSONDecoder().decode(
+                FinampWidgetState.self,
+                from: data
+            )
+        else {
+            return .empty
+        }
+
+        return state
+    }
+
+    func save() throws {
+        guard let stateURL = FinampWidgetShared.stateURL else {
+            throw NSError(
+                domain: "FinampWidget",
+                code: 20,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Unable to resolve widget state destination"
+                ]
+            )
+        }
+
+        let data = try JSONEncoder().encode(self)
+        try data.write(to: stateURL, options: .atomic)
+    }
+}

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -752,17 +752,18 @@
 		};
 		2ADE3ABB8648B6F61131CC47 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9740EEB31CF90195004384FC /* Generated.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = FinampWidget/FinampWidget.entitlements;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = PFNS8PTRM7;
 				FINAMP_WIDGET_APP_GROUP = group.com.unicornsonlsd.finamp-ios.widget;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FinampWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.unicornsonlsd.finamp-ios.FinampWidget";
 				PRODUCT_NAME = FinampWidgetExtension;
 				SDKROOT = iphoneos;
@@ -774,17 +775,18 @@
 		};
 		3EA712AA0A717D52DD10DB7A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9740EEB31CF90195004384FC /* Generated.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = FinampWidget/FinampWidget.entitlements;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = PFNS8PTRM7;
 				FINAMP_WIDGET_APP_GROUP = group.com.unicornsonlsd.finamp-ios.widget;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FinampWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.unicornsonlsd.finamp-ios.FinampWidget";
 				PRODUCT_NAME = FinampWidgetExtension;
 				SDKROOT = iphoneos;
@@ -977,17 +979,18 @@
 		};
 		98A73D88DEE833DB8B87E335 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9740EEB31CF90195004384FC /* Generated.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = FinampWidget/FinampWidget.entitlements;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = PFNS8PTRM7;
 				FINAMP_WIDGET_APP_GROUP = group.com.unicornsonlsd.finamp-ios.widget;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FinampWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.unicornsonlsd.finamp-ios.FinampWidget";
 				PRODUCT_NAME = FinampWidgetExtension;
 				SDKROOT = iphoneos;

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -3,25 +3,44 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		054164E5BCC2E1EB23712657 /* WidgetState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9219FBC823774B12AD10A148 /* WidgetState.swift */; };
+		070B40D53366E4BA8A1743FE /* FinampWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28CD9B0B742DD0DEECC18281 /* FinampWidget.swift */; };
+		0F4C9FF6B236AE6BDBFDAECA /* WidgetIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE857AA5A3AEC4D41C4CFD61 /* WidgetIntents.swift */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		1A7A01C825617F84005D4731 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A7A01C725617F74005D4731 /* libsqlite3.tbd */; };
 		1AB3434A28AEB3BA00B8C792 /* Info-Debug.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1AB3434728AEB3BA00B8C792 /* Info-Debug.plist */; };
 		1AB3434B28AEB3BA00B8C792 /* Info-Profile.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1AB3434828AEB3BA00B8C792 /* Info-Profile.plist */; };
 		1AB3434C28AEB3BA00B8C792 /* Info-Release.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1AB3434928AEB3BA00B8C792 /* Info-Release.plist */; };
 		23119D278A5EBCAEDB53CE23 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB7427A67C90F0206B85CCB6 /* Pods_Runner.framework */; };
+		2BB2C5861FB8AEAA4101C020 /* WidgetState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9219FBC823774B12AD10A148 /* WidgetState.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		4BC6EF751C7CA8D827E2A2A4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A0B6060686C82066EF2D8E34 /* Foundation.framework */; };
+		745A066FBC40771E79033371 /* WidgetBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB80671B0553835DCB014714 /* WidgetBridge.swift */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
+		7D121C6D2BE91DC5C1F3A1F8 /* .appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = AFAAE44C4F16859D26B9FB73 /* .appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		D0BA0CE30F4D9A1D0D9BF154 /* WidgetIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE857AA5A3AEC4D41C4CFD61 /* WidgetIntents.swift */; };
+		D629504BCBD803BABCBF9D46 /* FinampWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C78352A117253BADAE7DBC /* FinampWidgetBundle.swift */; };
 		D7E03F9A2ED4FFB100EEBE11 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E03F982ED4FFAE00EEBE11 /* SceneDelegate.swift */; };
 		D7E03F9B2ED4FFB200EEBE11 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E03F9C2ED4FFAF00EEBE11 /* CarPlaySceneDelegate.swift */; };
-		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		C5013B33EF13E8792F9C506C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D4795FF057D641372E66641D;
+			remoteInfo = FinampWidgetExtension;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		9705A1C41CF9048500538489 /* Embed Frameworks */ = {
@@ -32,6 +51,17 @@
 			files = (
 			);
 			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E65784F62311C2D84E20576D /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				7D121C6D2BE91DC5C1F3A1F8 /* .appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -119,16 +149,23 @@
 		1AD2DF432921A4DD006B24E3 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		1AD2DF442921A4FA006B24E3 /* szl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = szl; path = szl.lproj/Main.strings; sourceTree = "<group>"; };
 		1AD2DF452921A4FA006B24E3 /* szl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = szl; path = szl.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		28CD9B0B742DD0DEECC18281 /* FinampWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FinampWidget.swift; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		9219FBC823774B12AD10A148 /* WidgetState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetState.swift; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		97C146FB1CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		98C78352A117253BADAE7DBC /* FinampWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FinampWidgetBundle.swift; sourceTree = "<group>"; };
+		A0B6060686C82066EF2D8E34 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		AFAAE44C4F16859D26B9FB73 /* .appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = .appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB80671B0553835DCB014714 /* WidgetBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetBridge.swift; sourceTree = "<group>"; };
 		CF84AA0DC653871661EC5D9F /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		D71BDC432ED54E31006D7BB7 /* RunnerDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RunnerDebug.entitlements; sourceTree = "<group>"; };
 		D7E03F982ED4FFAE00EEBE11 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -137,10 +174,18 @@
 		E0FC81896D87FAC6F1E1B2C8 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		FB7427A67C90F0206B85CCB6 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FBA6030E2DB170CE0055CBBC /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
-		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
+		FE857AA5A3AEC4D41C4CFD61 /* WidgetIntents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetIntents.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		8FFC59BC3ADD34498044F3CA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4BC6EF751C7CA8D827E2A2A4 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -164,11 +209,20 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		20ADBE71E2BA99B268C3D703 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				A0B6060686C82066EF2D8E34 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
 		4ACC266EDBF72BDB7F9715BE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 				1A7A01C725617F74005D4731 /* libsqlite3.tbd */,
 				FB7427A67C90F0206B85CCB6 /* Pods_Runner.framework */,
+				20ADBE71E2BA99B268C3D703 /* iOS */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -193,6 +247,7 @@
 				97C146EF1CF9000F007C117D /* Products */,
 				17DBD18F82197DAAAF6A81C9 /* Pods */,
 				4ACC266EDBF72BDB7F9715BE /* Frameworks */,
+				EC6B40E802AB78A5FEDD188E /* FinampWidget */,
 			);
 			sourceTree = "<group>";
 		};
@@ -200,6 +255,7 @@
 			isa = PBXGroup;
 			children = (
 				97C146EE1CF9000F007C117D /* Runner.app */,
+				AFAAE44C4F16859D26B9FB73 /* .appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -221,21 +277,31 @@
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
+				BB80671B0553835DCB014714 /* WidgetBridge.swift */,
 			);
 			path = Runner;
+			sourceTree = "<group>";
+		};
+		EC6B40E802AB78A5FEDD188E /* FinampWidget */ = {
+			isa = PBXGroup;
+			children = (
+				9219FBC823774B12AD10A148 /* WidgetState.swift */,
+				FE857AA5A3AEC4D41C4CFD61 /* WidgetIntents.swift */,
+				28CD9B0B742DD0DEECC18281 /* FinampWidget.swift */,
+				98C78352A117253BADAE7DBC /* FinampWidgetBundle.swift */,
+			);
+			path = FinampWidget;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
 		97C146ED1CF9000F007C117D /* Runner */ = {
-			packageProductDependencies = (
-				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
-			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
 				9C98541034167616AED82644 /* [CP] Check Pods Manifest.lock */,
+				E65784F62311C2D84E20576D /* Embed App Extensions */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
@@ -243,23 +309,42 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				EA10DADE9639BB3D0A9BCBCE /* [CP] Embed Pods Frameworks */,
+				B04AFFF1BDDB6ED73FAB098E /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				93CA4F283EE42E12CBFD056C /* PBXTargetDependency */,
+			);
+			name = Runner;
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
+			productName = Runner;
+			productReference = 97C146EE1CF9000F007C117D /* Runner.app */;
+			productType = "com.apple.product-type.application";
+		};
+		D4795FF057D641372E66641D /* FinampWidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 22F4590A565081BA2985C2F9 /* Build configuration list for PBXNativeTarget "FinampWidgetExtension" */;
+			buildPhases = (
+				647EF703139B889E4636BFD5 /* Sources */,
+				8FFC59BC3ADD34498044F3CA /* Frameworks */,
+				3C75CF58C24419544401024E /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = Runner;
-			productName = Runner;
-			productReference = 97C146EE1CF9000F007C117D /* Runner.app */;
-			productType = "com.apple.product-type.application";
+			name = FinampWidgetExtension;
+			productName = FinampWidgetExtension;
+			productReference = AFAAE44C4F16859D26B9FB73 /* .appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		97C146E61CF9000F007C117D /* Project object */ = {
-			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
-			);
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1510;
@@ -318,16 +403,27 @@
 				id,
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
+				D4795FF057D641372E66641D /* FinampWidgetExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		3C75CF58C24419544401024E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EC1CF9000F007C117D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -398,6 +494,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		B04AFFF1BDDB6ED73FAB098E /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		EA10DADE9639BB3D0A9BCBCE /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -418,6 +531,17 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		647EF703139B889E4636BFD5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				054164E5BCC2E1EB23712657 /* WidgetState.swift in Sources */,
+				0F4C9FF6B236AE6BDBFDAECA /* WidgetIntents.swift in Sources */,
+				070B40D53366E4BA8A1743FE /* FinampWidget.swift in Sources */,
+				D629504BCBD803BABCBF9D46 /* FinampWidgetBundle.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EA1CF9000F007C117D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -426,10 +550,22 @@
 				D7E03F9B2ED4FFB200EEBE11 /* CarPlaySceneDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				D7E03F9A2ED4FFB100EEBE11 /* SceneDelegate.swift in Sources */,
+				745A066FBC40771E79033371 /* WidgetBridge.swift in Sources */,
+				2BB2C5861FB8AEAA4101C020 /* WidgetState.swift in Sources */,
+				D0BA0CE30F4D9A1D0D9BF154 /* WidgetIntents.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		93CA4F283EE42E12CBFD056C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = FinampWidgetExtension;
+			target = D4795FF057D641372E66641D /* FinampWidgetExtension */;
+			targetProxy = C5013B33EF13E8792F9C506C /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		97C146FA1CF9000F007C117D /* Main.storyboard */ = {
@@ -590,6 +726,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = PFNS8PTRM7;
 				ENABLE_BITCODE = NO;
+				FINAMP_WIDGET_APP_GROUP = group.com.unicornsonlsd.finamp-ios.widget;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -612,6 +749,49 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Profile;
+		};
+		2ADE3ABB8648B6F61131CC47 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = FinampWidget/FinampWidget.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = PFNS8PTRM7;
+				FINAMP_WIDGET_APP_GROUP = group.com.unicornsonlsd.finamp-ios.widget;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = FinampWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.unicornsonlsd.finamp-ios.FinampWidget";
+				PRODUCT_NAME = FinampWidgetExtension;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Profile;
+		};
+		3EA712AA0A717D52DD10DB7A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = FinampWidget/FinampWidget.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = PFNS8PTRM7;
+				FINAMP_WIDGET_APP_GROUP = group.com.unicornsonlsd.finamp-ios.widget;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = FinampWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.unicornsonlsd.finamp-ios.FinampWidget";
+				PRODUCT_NAME = FinampWidgetExtension;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
 		};
 		97C147031CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -734,6 +914,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = PFNS8PTRM7;
 				ENABLE_BITCODE = NO;
+				FINAMP_WIDGET_APP_GROUP = group.com.unicornsonlsd.finamp-ios.widget;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -770,6 +951,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = PFNS8PTRM7;
 				ENABLE_BITCODE = NO;
+				FINAMP_WIDGET_APP_GROUP = group.com.unicornsonlsd.finamp-ios.widget;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -793,9 +975,41 @@
 			};
 			name = Release;
 		};
+		98A73D88DEE833DB8B87E335 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = FinampWidget/FinampWidget.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = PFNS8PTRM7;
+				FINAMP_WIDGET_APP_GROUP = group.com.unicornsonlsd.finamp-ios.widget;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = FinampWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.unicornsonlsd.finamp-ios.FinampWidget";
+				PRODUCT_NAME = FinampWidgetExtension;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		22F4590A565081BA2985C2F9 /* Build configuration list for PBXNativeTarget "FinampWidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				98A73D88DEE833DB8B87E335 /* Release */,
+				3EA712AA0A717D52DD10DB7A /* Debug */,
+				2ADE3ABB8648B6F61131CC47 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		97C146E91CF9000F007C117D /* Build configuration list for PBXProject "Runner" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -817,12 +1031,14 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};
 /* End XCLocalSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -26,6 +26,9 @@ let flutterEngine = FlutterEngine(name: "SharedEngine", project: nil, allowHeadl
         // Set up method channel for Siri media intent handling
         setupSiriIntentChannel()
 
+        // Synchronize Now Playing state with the WidgetKit extension.
+        setupWidgetChannel()
+
         // Exclude the documents and support folders from iCloud backup since we keep songs there.
         if let documentsDir = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true) {
             try? setExcludeFromiCloudBackup(documentsDir, isExcluded: true)
@@ -99,7 +102,7 @@ private func setExcludeFromiCloudBackup(_ dir: URL, isExcluded: Bool) throws {
 extension AppDelegate {
     func setupPlaybackStateChannel() {
         let channel = FlutterMethodChannel(
-            name: "\(Bundle.main.bundleIdentifier!)/playback_state",
+            name: "com.unicornsonlsd.finamp-ios/playback_state",
             binaryMessenger: flutterEngine.binaryMessenger
         )
 
@@ -132,7 +135,7 @@ private var siriIntentChannel: FlutterMethodChannel?
 extension AppDelegate {
     func setupSiriIntentChannel() {
         siriIntentChannel = FlutterMethodChannel(
-            name: "\(Bundle.main.bundleIdentifier!)/siri_intent",
+            name: "com.unicornsonlsd.finamp-ios/siri_intent",
             binaryMessenger: flutterEngine.binaryMessenger
         )
     }

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -6,5 +6,9 @@
 	<true/>
 	<key>com.apple.developer.siri</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(FINAMP_WIDGET_APP_GROUP)</string>
+	</array>
 </dict>
 </plist>

--- a/ios/Runner/WidgetBridge.swift
+++ b/ios/Runner/WidgetBridge.swift
@@ -1,0 +1,367 @@
+import Flutter
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+import WidgetKit
+
+extension AppDelegate {
+    func setupWidgetChannel() {
+        let channel = FlutterMethodChannel(
+            name: "finamp/ios_widget",
+            binaryMessenger: flutterEngine.binaryMessenger
+        )
+        let actionState = FinampWidgetActionState()
+
+        FinampWidgetActionDispatcher.handler = { action, rating in
+            actionState.begin()
+            defer { actionState.end() }
+
+            let arguments: [String: Any] = [
+                "action": action.rawValue,
+                "rating": rating as Any
+            ]
+
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, Error>) in
+
+                channel.invokeMethod(
+                    "performAction",
+                    arguments: arguments
+                ) { result in
+                    if let error = result as? FlutterError {
+                        continuation.resume(
+                            throwing: NSError(
+                                domain: "FinampWidget",
+                                code: 1,
+                                userInfo: [
+                                    NSLocalizedDescriptionKey:
+                                        error.message ?? error.code
+                                ]
+                            )
+                        )
+                        return
+                    }
+
+                    guard let state = result as? [String: Any] else {
+                        continuation.resume(
+                            throwing: NSError(
+                                domain: "FinampWidget",
+                                code: 4,
+                                userInfo: [
+                                    NSLocalizedDescriptionKey:
+                                        "Widget action did not return a state snapshot"
+                                ]
+                            )
+                        )
+                        return
+                    }
+
+                    do {
+                        try FinampWidgetStateWriter.writeState(
+                            state,
+                            reload: false
+                        )
+                        continuation.resume()
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+        }
+
+        channel.setMethodCallHandler { call, result in
+            switch call.method {
+            case "updateState":
+                guard let arguments = call.arguments as? [String: Any] else {
+                    result(FlutterError(
+                        code: "INVALID_ARGS",
+                        message: "Widget state must be a dictionary",
+                        details: nil
+                    ))
+                    return
+                }
+
+                do {
+                    let reload =
+                        (arguments["reload"] as? Bool ?? true) &&
+                        !actionState.isActive
+                    try FinampWidgetStateWriter.writeState(
+                        arguments,
+                        reload: reload
+                    )
+                    result(nil)
+                } catch {
+                    result(FlutterError(
+                        code: "WIDGET_STATE_WRITE_FAILED",
+                        message: error.localizedDescription,
+                        details: nil
+                    ))
+                }
+
+            case "updateArtwork":
+                guard
+                    let arguments = call.arguments as? [String: Any],
+                    let itemID = arguments["itemID"] as? String,
+                    let typedData = arguments["bytes"] as? FlutterStandardTypedData
+                else {
+                    result(FlutterError(
+                        code: "INVALID_ARTWORK_ARGS",
+                        message: "Widget artwork requires itemID and bytes",
+                        details: nil
+                    ))
+                    return
+                }
+
+                do {
+                    let reload =
+                        (arguments["reload"] as? Bool ?? true) &&
+                        !actionState.isActive
+                    try FinampWidgetStateWriter.writeArtwork(
+                        typedData.data,
+                        itemID: itemID,
+                        reload: reload
+                    )
+                    result(nil)
+                } catch {
+                    result(FlutterError(
+                        code: "WIDGET_ARTWORK_WRITE_FAILED",
+                        message: error.localizedDescription,
+                        details: nil
+                    ))
+                }
+
+            default:
+                result(FlutterMethodNotImplemented)
+            }
+        }
+    }
+}
+
+private final class FinampWidgetActionState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var depth = 0
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return depth > 0
+    }
+
+    func begin() {
+        lock.lock()
+        depth += 1
+        lock.unlock()
+    }
+
+    func end() {
+        lock.lock()
+        depth = max(0, depth - 1)
+        lock.unlock()
+    }
+}
+
+private enum FinampWidgetStateWriter {
+    private static let maxCoverPixelSize = 1280
+    private static let jpegCompressionQuality = 0.9
+
+    private static var appGroup: String {
+        "group.\(Bundle.main.bundleIdentifier ?? "com.unicornsonlsd.finamp-ios").widget"
+    }
+
+    private static var containerURL: URL? {
+        FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: appGroup
+        )
+    }
+
+    private static var stateURL: URL? {
+        containerURL?.appendingPathComponent(FinampWidgetShared.stateFileName)
+    }
+
+    static func writeState(
+        _ arguments: [String: Any],
+        reload: Bool
+    ) throws {
+        let oldState = loadState()
+
+        var state = oldState
+        state.itemID = arguments["itemID"] as? String
+        state.title = arguments["title"] as? String ?? "Finamp"
+        state.artist = arguments["artist"] as? String ?? ""
+        state.album = arguments["album"] as? String ?? ""
+        state.isPlaying = arguments["isPlaying"] as? Bool ?? false
+        state.showStarRatings = arguments["showStarRatings"] as? Bool ?? false
+        state.isFavorite = arguments["isFavorite"] as? Bool ?? false
+        state.starRating = (arguments["starRating"] as? NSNumber)?.doubleValue
+
+        if state == oldState {
+            return
+        }
+
+        if oldState.itemID != state.itemID, let oldID = oldState.itemID {
+            removeCover(itemID: oldID)
+        }
+
+        try save(state)
+        if reload {
+            reloadWidget()
+        }
+    }
+
+    static func writeArtwork(
+        _ data: Data,
+        itemID: String,
+        reload: Bool
+    ) throws {
+        var state = loadState()
+        guard state.itemID == itemID else {
+            return
+        }
+
+        guard let destination = coverURL(itemID: itemID) else {
+            throw NSError(
+                domain: "FinampWidget",
+                code: 11,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Unable to resolve widget artwork destination"
+                ]
+            )
+        }
+
+        let normalizedData = try normalizeCoverData(data)
+
+        if let existingData = try? Data(contentsOf: destination),
+           existingData == normalizedData {
+            return
+        }
+
+        try normalizedData.write(to: destination, options: .atomic)
+        state.coverRevision &+= 1
+        try save(state)
+        if reload {
+            reloadWidget()
+        }
+    }
+
+    private static func loadState() -> FinampWidgetState {
+        guard
+            let stateURL,
+            let data = try? Data(contentsOf: stateURL),
+            let state = try? JSONDecoder().decode(
+                FinampWidgetState.self,
+                from: data
+            )
+        else {
+            return .empty
+        }
+        return state
+    }
+
+    private static func save(_ state: FinampWidgetState) throws {
+        guard let stateURL else {
+            throw NSError(
+                domain: "FinampWidget",
+                code: 10,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Unable to resolve widget state destination"
+                ]
+            )
+        }
+
+        let data = try JSONEncoder().encode(state)
+        try data.write(to: stateURL, options: .atomic)
+    }
+
+    private static func normalizeCoverData(_ data: Data) throws -> Data {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+            throw NSError(
+                domain: "FinampWidget",
+                code: 12,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Unable to decode widget artwork"
+                ]
+            )
+        }
+
+        let thumbnailOptions: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxCoverPixelSize,
+            kCGImageSourceShouldCacheImmediately: true
+        ]
+
+        guard let image = CGImageSourceCreateThumbnailAtIndex(
+            source,
+            0,
+            thumbnailOptions as CFDictionary
+        ) else {
+            throw NSError(
+                domain: "FinampWidget",
+                code: 13,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Unable to downsample widget artwork"
+                ]
+            )
+        }
+
+        let output = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            output,
+            UTType.jpeg.identifier as CFString,
+            1,
+            nil
+        ) else {
+            throw NSError(
+                domain: "FinampWidget",
+                code: 14,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Unable to create widget artwork encoder"
+                ]
+            )
+        }
+
+        let properties: [CFString: Any] = [
+            kCGImageDestinationLossyCompressionQuality: jpegCompressionQuality
+        ]
+        CGImageDestinationAddImage(
+            destination,
+            image,
+            properties as CFDictionary
+        )
+
+        guard CGImageDestinationFinalize(destination) else {
+            throw NSError(
+                domain: "FinampWidget",
+                code: 15,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Unable to encode widget artwork"
+                ]
+            )
+        }
+
+        return output as Data
+    }
+
+    private static func reloadWidget() {
+        WidgetCenter.shared.reloadTimelines(ofKind: FinampWidgetShared.kind)
+    }
+
+    private static func coverURL(itemID: String) -> URL? {
+        containerURL?
+            .appendingPathComponent(
+                "\(FinampWidgetShared.coverFileName)-\(itemID)"
+            )
+            .appendingPathExtension("jpg")
+    }
+
+    private static func removeCover(itemID: String) {
+        guard let url = coverURL(itemID: itemID) else { return }
+        try? FileManager.default.removeItem(at: url)
+    }
+}

--- a/lib/components/PlayerScreen/track_name_content.dart
+++ b/lib/components/PlayerScreen/track_name_content.dart
@@ -2,6 +2,7 @@ import 'package:finamp/components/AddToPlaylistScreen/add_to_playlist_button.dar
 import 'package:finamp/components/PlayerScreen/album_chip.dart';
 import 'package:finamp/components/PlayerScreen/artist_chip.dart';
 import 'package:finamp/components/PlayerScreen/player_buttons_more.dart';
+import 'package:finamp/components/PlayerScreen/track_rating.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/jellyfin_models.dart' as jellyfin_models;
 import 'package:finamp/screens/player_screen.dart';
@@ -27,6 +28,8 @@ class TrackNameContent extends ConsumerWidget {
     final currentTrack = queue!.currentTrack!;
 
     final jellyfin_models.BaseItemDto trackBaseItemDto = currentTrack.baseItem;
+    final showStarRatings = ref.watch(finampSettingsProvider.showStarRatings);
+    final chipBackgroundColor = IconTheme.of(context).color!.withValues(alpha: 0.1);
 
     Widget getContent(BoxConstraints constraints, double padding) => Column(
       crossAxisAlignment: CrossAxisAlignment.center,
@@ -106,20 +109,26 @@ class TrackNameContent extends ConsumerWidget {
           children: [
             PlayerButtonsMore(item: trackBaseItemDto, queueItem: currentTrack),
             Flexible(
-              child: ArtistChips(
-                baseItem: trackBaseItemDto,
-                backgroundColor: IconTheme.of(context).color!.withOpacity(0.1),
-              ),
+              child: showStarRatings
+                  ? TrackRating(baseItem: trackBaseItemDto)
+                  : ArtistChips(baseItem: trackBaseItemDto, backgroundColor: chipBackgroundColor),
             ),
             AddToPlaylistButton(item: trackBaseItemDto, queueItem: currentTrack),
           ],
         ),
+        if (showStarRatings)
+          Center(
+            child: Container(
+              constraints: const BoxConstraints(maxWidth: 280),
+              child: ArtistChips(baseItem: trackBaseItemDto, backgroundColor: chipBackgroundColor),
+            ),
+          ),
         Center(
           child: Container(
             constraints: const BoxConstraints(maxWidth: 280),
             child: AlbumChips(
               baseItem: trackBaseItemDto,
-              backgroundColor: IconTheme.of(context).color!.withOpacity(0.1),
+              backgroundColor: chipBackgroundColor,
               key: trackBaseItemDto.album == null ? null : ValueKey("${trackBaseItemDto.album}-album"),
             ),
           ),

--- a/lib/components/PlayerScreen/track_rating.dart
+++ b/lib/components/PlayerScreen/track_rating.dart
@@ -1,0 +1,125 @@
+import 'dart:async';
+
+import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/models/jellyfin_models.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:finamp/services/user_rating_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class TrackRating extends ConsumerStatefulWidget {
+  const TrackRating({super.key, required this.baseItem});
+
+  final BaseItemDto baseItem;
+
+  @override
+  ConsumerState<TrackRating> createState() => _TrackRatingState();
+}
+
+class _TrackRatingState extends ConsumerState<TrackRating> {
+  static const _starWidth = 44.0;
+  static const _starCount = 5;
+
+  double? _dragRating;
+
+  double _ratingForPosition(double dx, {required bool allowHalfStars}) {
+    if (dx <= 0) return 0;
+
+    final raw = (dx / _starWidth).clamp(0.0, _starCount.toDouble());
+    final steps = allowHalfStars ? 2.0 : 1.0;
+
+    return ((raw * steps).ceil() / steps).clamp(allowHalfStars ? 0.5 : 1.0, _starCount.toDouble());
+  }
+
+  void _updateDrag(Offset localPosition, {required bool allowHalfStars}) {
+    setState(() {
+      _dragRating = _ratingForPosition(localPosition.dx, allowHalfStars: allowHalfStars);
+    });
+  }
+
+  void _finishDrag() {
+    final rating = _dragRating;
+    if (rating == null) return;
+
+    setState(() => _dragRating = null);
+    unawaited(setUserRating(ref, widget.baseItem, rating == 0 ? null : rating));
+  }
+
+  void _cancelDrag() {
+    if (_dragRating == null) return;
+    setState(() => _dragRating = null);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ratingProvider = userRatingProvider(widget.baseItem);
+    final rating = ref.watch(ratingProvider);
+    final isUpdating = ref.watch(userRatingUpdatingProvider(widget.baseItem.id));
+    final allowHalfStars = ref.watch(finampSettingsProvider.allowHalfStarRatings);
+
+    final storedStars = ratingToStarValue(rating);
+    final selectedStars = _dragRating ?? (allowHalfStars ? storedStars : storedStars.roundToDouble());
+
+    final displayRating = selectedStars % 1 == 0 ? selectedStars.toInt().toString() : selectedStars.toString();
+
+    final l10n = AppLocalizations.of(context)!;
+    final ratingLabel = selectedStars == 0 ? l10n.starRatingNotRated : l10n.starRatingValueLabel(displayRating);
+
+    return Semantics(
+      container: true,
+      label: ratingLabel,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onHorizontalDragStart: isUpdating
+            ? null
+            : (details) => _updateDrag(details.localPosition, allowHalfStars: allowHalfStars),
+        onHorizontalDragUpdate: isUpdating
+            ? null
+            : (details) => _updateDrag(details.localPosition, allowHalfStars: allowHalfStars),
+        onHorizontalDragEnd: isUpdating ? null : (_) => _finishDrag(),
+        onHorizontalDragCancel: isUpdating ? null : _cancelDrag,
+        child: SizedBox(
+          width: _starWidth * _starCount,
+          height: _starWidth,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: List.generate(_starCount, (index) {
+              final stars = index + 1;
+              final remaining = selectedStars - index;
+
+              final icon = remaining >= 1
+                  ? Icons.star_rounded
+                  : remaining >= 0.5
+                  ? Icons.star_half_rounded
+                  : Icons.star_border_rounded;
+
+              final clearsRating = selectedStars == stars;
+              final starLabel = l10n.starRatingValueLabel(stars.toString());
+
+              return Semantics(
+                button: true,
+                enabled: !isUpdating,
+                label: starLabel,
+                selected: clearsRating,
+                excludeSemantics: true,
+                child: SizedBox(
+                  width: _starWidth,
+                  height: _starWidth,
+                  child: IconButton(
+                    padding: EdgeInsets.zero,
+                    tooltip: clearsRating ? l10n.clearStarRating : starLabel,
+                    iconSize: 24,
+                    onPressed: isUpdating
+                        ? null
+                        : () => unawaited(setUserRating(ref, widget.baseItem, clearsRating ? null : stars)),
+                    icon: Icon(icon),
+                  ),
+                ),
+              );
+            }),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3743,5 +3743,39 @@
     "quickSettingsTranscodeLink": "All transcoding settings",
     "quickSettingsLayoutLink": "All layout & theme settings",
     "quickSettingsAllSettingsLink": "All Settings",
-    "quickSettingsNetworkLink": "Configure the local address for your server"
+    "quickSettingsNetworkLink": "Configure the local address for your server",
+    "showStarRatingsTitle": "Show star ratings",
+    "@showStarRatingsTitle": {
+        "description": "Title for the setting that shows personal Jellyfin star ratings in the player."
+    },
+    "showStarRatingsSubtitle": "Show your personal Jellyfin rating in the player, lyrics view, and supported system media controls.",
+    "@showStarRatingsSubtitle": {
+        "description": "Subtitle for the setting that shows personal Jellyfin star ratings."
+    },
+    "allowHalfStarRatingsTitle": "Allow half-star ratings",
+    "@allowHalfStarRatingsTitle": {
+        "description": "Title for the setting that enables half-star rating increments."
+    },
+    "allowHalfStarRatingsSubtitle": "Swipe across the stars to choose ratings in half-star steps.",
+    "@allowHalfStarRatingsSubtitle": {
+        "description": "Subtitle for the setting that enables half-star rating increments."
+    },
+    "starRatingNotRated": "Not rated",
+    "@starRatingNotRated": {
+        "description": "Accessibility label for a track that has no personal star rating."
+    },
+    "starRatingValueLabel": "{rating} of 5 stars",
+    "@starRatingValueLabel": {
+        "description": "Accessibility label and tooltip for a personal star rating.",
+        "placeholders": {
+            "rating": {
+                "type": "String",
+                "example": "4.5"
+            }
+        }
+    },
+    "clearStarRating": "Clear rating",
+    "@clearStarRating": {
+        "description": "Tooltip for clearing the personal star rating of a track."
+    }
 }

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -318,6 +318,8 @@ class DefaultSettings {
   static const useAndroidGainEffect = true;
   static const ClientCertificate? clientCertificate = null;
   static const showQuickActionsBanner = true;
+  static const showStarRatings = false;
+  static const allowHalfStarRatings = false;
 }
 
 @HiveType(typeId: 28)
@@ -466,6 +468,8 @@ class FinampSettings {
     this.clientCertificate = DefaultSettings.clientCertificate,
     this.showQuickActionsBanner = DefaultSettings.showQuickActionsBanner,
     this.perTabContentViewType = DefaultSettings.perTabContentViewType,
+    this.showStarRatings = DefaultSettings.showStarRatings,
+    this.allowHalfStarRatings = DefaultSettings.allowHalfStarRatings,
   });
 
   @HiveField(0, defaultValue: DefaultSettings.isOffline)
@@ -966,6 +970,15 @@ class FinampSettings {
   @HiveField(155, defaultValue: DefaultSettings.perTabContentViewType)
   @SettingsHelperMap("tabContentType")
   Map<ContentType, ContentViewType> perTabContentViewType;
+
+  /// Whether personal Jellyfin star ratings are shown in the player and
+  /// exposed to supported system media controls.
+  @HiveField(156, defaultValue: DefaultSettings.showStarRatings)
+  bool showStarRatings;
+
+  /// Whether the in-app rating control allows half-star increments.
+  @HiveField(157, defaultValue: DefaultSettings.allowHalfStarRatings)
+  bool allowHalfStarRatings;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(
@@ -4427,6 +4440,7 @@ enum FinampQuickActions {
   surpriseMe(true),
   @HiveField(9)
   playSpecificItem(true);
+
   // ID 10 moved upwards for more sensible user-facing ordering
   //TODO support album/artist shuffle (requires queue support)
 

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -463,6 +463,8 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
                 ContentType.genres: ContentViewType.list,
               }
             : (fields[155] as Map).cast<ContentType, ContentViewType>(),
+        showStarRatings: fields[156] == null ? false : fields[156] as bool,
+        allowHalfStarRatings: fields[157] == null ? false : fields[157] as bool,
       )
       ..sortBy = fields[7] as SortBy?
       ..sortOrder = fields[8] as SortOrder?
@@ -486,7 +488,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(149)
+      ..writeByte(151)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -784,7 +786,11 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(154)
       ..write(obj.showQuickActionsBanner)
       ..writeByte(155)
-      ..write(obj.perTabContentViewType);
+      ..write(obj.perTabContentViewType)
+      ..writeByte(156)
+      ..write(obj.showStarRatings)
+      ..writeByte(157)
+      ..write(obj.allowHalfStarRatings);
   }
 
   @override

--- a/lib/screens/player_settings_screen.dart
+++ b/lib/screens/player_settings_screen.dart
@@ -64,6 +64,8 @@ class PlayerSettingsScreen extends ConsumerWidget {
                 FinampSetters.setFeatureChipsConfiguration(oldFeatureChipsConfig.copyWith(features: oldFeatures));
               },
             ),
+          ShowStarRatingsToggle(),
+          if (ref.watch(finampSettingsProvider.showStarRatings)) AllowHalfStarRatingsToggle(),
           ShowAlbumReleaseDateOnPlayerScreenToggle(),
           PlayerScreenMinimumCoverPaddingEditor(),
           SuppressPlayerPaddingSwitch(),
@@ -71,6 +73,35 @@ class PlayerSettingsScreen extends ConsumerWidget {
           HidePlayerBottomActionsSwitch(),
         ],
       ),
+    );
+  }
+}
+
+class ShowStarRatingsToggle extends ConsumerWidget {
+  const ShowStarRatingsToggle({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile.adaptive(
+      title: Text(AppLocalizations.of(context)!.showStarRatingsTitle),
+      subtitle: Text(AppLocalizations.of(context)!.showStarRatingsSubtitle),
+      value: ref.watch(finampSettingsProvider.showStarRatings),
+      onChanged: FinampSetters.setShowStarRatings,
+    );
+  }
+}
+
+class AllowHalfStarRatingsToggle extends ConsumerWidget {
+  const AllowHalfStarRatingsToggle({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile.adaptive(
+      contentPadding: const EdgeInsets.only(left: 32, right: 16),
+      title: Text(AppLocalizations.of(context)!.allowHalfStarRatingsTitle),
+      subtitle: Text(AppLocalizations.of(context)!.allowHalfStarRatingsSubtitle),
+      value: ref.watch(finampSettingsProvider.allowHalfStarRatings),
+      onChanged: FinampSetters.setAllowHalfStarRatings,
     );
   }
 }

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -76,6 +76,8 @@ class FinampSettingsHelper {
     finampSettingsTemp.suppressPlayerPadding = DefaultSettings.suppressPlayerPadding;
     finampSettingsTemp.prioritizeCoverFactor = DefaultSettings.prioritizeCoverFactor;
     finampSettingsTemp.hidePlayerBottomActions = DefaultSettings.hidePlayerBottomActions;
+    finampSettingsTemp.showStarRatings = DefaultSettings.showStarRatings;
+    finampSettingsTemp.allowHalfStarRatings = DefaultSettings.allowHalfStarRatings;
 
     Hive.box<FinampSettings>("FinampSettings").put("FinampSettings", finampSettingsTemp);
   }

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1317,6 +1317,22 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setShowStarRatings(bool newShowStarRatings) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.showStarRatings = newShowStarRatings;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
+  static void setAllowHalfStarRatings(bool newAllowHalfStarRatings) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.allowHalfStarRatings = newAllowHalfStarRatings;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1763,6 +1779,11 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
   ) => finampSettingsProvider.select(
     (value) => value.requireValue.perTabContentViewType[tabContentType],
   );
+  ProviderListenable<bool> get showStarRatings => finampSettingsProvider.select(
+    (value) => value.requireValue.showStarRatings,
+  );
+  ProviderListenable<bool> get allowHalfStarRatings => finampSettingsProvider
+      .select((value) => value.requireValue.allowHalfStarRatings);
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(
         (value) => value.requireValue.downloadTranscodingProfile,

--- a/lib/services/ios_widget_service.dart
+++ b/lib/services/ios_widget_service.dart
@@ -1,0 +1,462 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:audio_service/audio_service.dart';
+import 'package:finamp/gen/assets.gen.dart';
+import 'package:finamp/models/finamp_models.dart';
+import 'package:finamp/models/jellyfin_models.dart';
+import 'package:finamp/services/favorite_provider.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:finamp/services/jellyfin_api_helper.dart';
+import 'package:finamp/services/queue_service.dart';
+import 'package:finamp/services/user_rating_provider.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logging/logging.dart';
+
+/// Synchronizes Finamp's current media state with the iOS WidgetKit extension
+/// and dispatches widget actions back through the existing Finamp services.
+///
+/// The widget extension only receives presentation state. Jellyfin credentials
+/// and network access remain in the main Finamp process.
+class IosWidgetService {
+  IosWidgetService._();
+
+  static final instance = IosWidgetService._();
+
+  static const _channel = MethodChannel('finamp/ios_widget');
+  static const _intentStateTimeout = Duration(seconds: 2);
+  final _log = Logger('IosWidgetService');
+
+  StreamSubscription<MediaItem?>? _mediaItemSubscription;
+  StreamSubscription<PlaybackState>? _playbackStateSubscription;
+  StreamSubscription<FinampQueueItem?>? _currentTrackSubscription;
+  ProviderSubscription<bool>? _showRatingsSubscription;
+  ProviderSubscription<bool>? _favoriteSubscription;
+  ProviderSubscription<double?>? _ratingSubscription;
+
+  AudioHandler? _audioHandler;
+
+  Future<void> _syncTail = Future<void>.value();
+  String? _artworkTrackItemID;
+  String? _publishedArtworkItemID;
+  Completer<void>? _artworkReadyCompleter;
+  int _widgetActionDepth = 0;
+  bool _queueServiceBound = false;
+  bool _initialized = false;
+
+  bool get _isHandlingWidgetAction => _widgetActionDepth > 0;
+
+  Future<void> initialize({required AudioHandler audioHandler}) async {
+    if (!Platform.isIOS || _initialized) return;
+
+    _audioHandler = audioHandler;
+    _channel.setMethodCallHandler(_handleNativeCall);
+
+    _mediaItemSubscription = audioHandler.mediaItem.listen((mediaItem) {
+      _bindQueueServiceIfAvailable();
+      unawaited(_handleMediaItemUpdate(mediaItem));
+    });
+
+    // PlaybackState is Finamp's published playback truth. It is only used as
+    // an event source here; snapshots read its current value directly.
+    _playbackStateSubscription = audioHandler.playbackState.listen((_) {
+      _bindQueueServiceIfAvailable();
+      unawaited(syncNow());
+    });
+
+    final container = GetIt.instance<ProviderContainer>();
+    _showRatingsSubscription = container.listen<bool>(
+      finampSettingsProvider.showStarRatings,
+      (_, __) => unawaited(syncNow()),
+      fireImmediately: true,
+    );
+
+    // MusicPlayerBackgroundTask is constructed inside AudioService.init().
+    // QueueService is registered only after AudioService.init() completes, so
+    // bind it lazily as soon as Finamp makes it available.
+    _bindQueueServiceIfAvailable();
+    _initialized = true;
+  }
+
+  void _bindQueueServiceIfAvailable() {
+    if (_queueServiceBound || !GetIt.instance.isRegistered<QueueService>()) {
+      return;
+    }
+
+    final queueService = GetIt.instance<QueueService>();
+    final currentItem = queueService.getCurrentTrackStream().value?.baseItem;
+    _queueServiceBound = true;
+    _trackArtworkForItem(currentItem?.id.raw);
+    _bindItemProviders(currentItem);
+
+    _currentTrackSubscription = queueService.getCurrentTrackStream().listen((queueItem) {
+      _trackArtworkForItem(queueItem?.baseItem.id.raw);
+      _bindItemProviders(queueItem?.baseItem);
+      unawaited(syncNow());
+    });
+  }
+
+  Future<void> _handleMediaItemUpdate(MediaItem? mediaItem) async {
+    _bindQueueServiceIfAvailable();
+
+    // QueueService in redesign deliberately publishes the MediaItem more than
+    // once for the same track: metadata may be updated independently, and the
+    // full-quality albumImageProvider later replaces placeholder artwork with
+    // a local cached file. Persist the current track state before artwork so
+    // the native writer can validate the matching item ID.
+    await syncNow();
+
+    if (mediaItem == null) return;
+
+    // Artwork ownership is defined by this MediaItem snapshot itself. A newer
+    // MediaItem for the same track does not make a valid local artwork file
+    // stale; only a real track change does. This matters for cold image-cache
+    // loads where Finamp may publish several same-track MediaItems while the
+    // full-quality image is being prepared.
+    final item = _itemFromMediaItem(mediaItem);
+    final artUri = mediaItem.artUri;
+    if (item == null || artUri == null || !artUri.isScheme('file')) return;
+    if (_isPlaceholderArtwork(artUri)) return;
+
+    final liveItem = _liveCurrentQueueItem()?.baseItem;
+    if (liveItem != null && liveItem.id != item.id) return;
+
+    try {
+      final bytes = await File.fromUri(artUri).readAsBytes();
+      if (bytes.isEmpty) return;
+
+      // File I/O is asynchronous. Re-check only track identity afterwards;
+      // another MediaItem event for the same track is harmless and must not
+      // cancel this valid artwork publication.
+      final currentItem = _liveCurrentQueueItem()?.baseItem;
+      if (currentItem != null && currentItem.id != item.id) return;
+
+      await _channel.invokeMethod<void>('updateArtwork', <String, Object>{
+        'itemID': item.id.raw,
+        'bytes': bytes,
+        'reload': !_isHandlingWidgetAction,
+      });
+      _markArtworkPublished(item.id.raw);
+    } catch (error, stackTrace) {
+      _log.warning('Failed to publish iOS widget artwork from $artUri', error, stackTrace);
+    }
+  }
+
+  BaseItemDto? _itemFromMediaItem(MediaItem? mediaItem) {
+    final itemJson = mediaItem?.extras?['itemJson'];
+    if (itemJson is! Map) return null;
+
+    try {
+      return BaseItemDto.fromJson(Map<String, dynamic>.from(itemJson));
+    } catch (error, stackTrace) {
+      _log.warning('Failed to decode iOS widget item from MediaItem extras', error, stackTrace);
+      return null;
+    }
+  }
+
+  FinampQueueItem? _liveCurrentQueueItem() {
+    _bindQueueServiceIfAvailable();
+    if (!GetIt.instance.isRegistered<QueueService>()) return null;
+    return GetIt.instance<QueueService>().getCurrentTrackStream().value;
+  }
+
+  void _trackArtworkForItem(String? itemID) {
+    if (_artworkTrackItemID == itemID) return;
+
+    final previousCompleter = _artworkReadyCompleter;
+    if (previousCompleter != null && !previousCompleter.isCompleted) {
+      previousCompleter.complete();
+    }
+
+    _artworkTrackItemID = itemID;
+    _publishedArtworkItemID = null;
+    _artworkReadyCompleter = null;
+  }
+
+  void _markArtworkPublished(String itemID) {
+    if (_artworkTrackItemID != itemID) return;
+
+    _publishedArtworkItemID = itemID;
+    final completer = _artworkReadyCompleter;
+    if (completer != null && !completer.isCompleted) {
+      completer.complete();
+    }
+  }
+
+  Future<void> _waitForArtworkPublication(BaseItemDto item) async {
+    if (item.imageId == null) return;
+
+    final liveItem = _liveCurrentQueueItem()?.baseItem;
+    if (liveItem == null || liveItem.id != item.id) return;
+
+    final itemID = item.id.raw;
+    _trackArtworkForItem(itemID);
+    if (_publishedArtworkItemID == itemID) return;
+
+    final completer = _artworkReadyCompleter ??= Completer<void>();
+    try {
+      await completer.future.timeout(_intentStateTimeout);
+    } on TimeoutException {
+      _log.warning('Timed out waiting for iOS widget artwork: item=$itemID');
+    }
+  }
+
+  bool _isPlaceholderArtwork(Uri artUri) {
+    final placeholderPath = Assets.images.albumWhite.path;
+    return artUri.path == placeholderPath || artUri.path.endsWith('/$placeholderPath');
+  }
+
+  void _bindItemProviders(BaseItemDto? item) {
+    _favoriteSubscription?.close();
+    _favoriteSubscription = null;
+    _ratingSubscription?.close();
+    _ratingSubscription = null;
+
+    if (item == null) return;
+
+    final container = GetIt.instance<ProviderContainer>();
+
+    _favoriteSubscription = container.listen<bool>(
+      isFavoriteProvider(item),
+      (_, __) => unawaited(syncNow()),
+      fireImmediately: true,
+    );
+
+    _ratingSubscription = container.listen<double?>(
+      userRatingProvider(item),
+      (_, __) => unawaited(syncNow()),
+      fireImmediately: true,
+    );
+  }
+
+  Future<Object?> _handleNativeCall(MethodCall call) async {
+    if (call.method != 'performAction') {
+      throw MissingPluginException('Unknown iOS widget method: ${call.method}');
+    }
+
+    _bindQueueServiceIfAvailable();
+
+    final arguments = Map<String, dynamic>.from((call.arguments as Map?) ?? const <String, dynamic>{});
+    final action = arguments['action'] as String?;
+    final handler = _audioHandler;
+
+    if (handler == null || action == null) {
+      throw StateError('iOS widget bridge is not initialized');
+    }
+
+    _widgetActionDepth++;
+    try {
+      switch (action) {
+        case 'togglePlayback':
+          final expectedPlaying = !handler.playbackState.value.playing;
+          final confirmation = _waitForPlaybackState(expectedPlaying);
+          if (expectedPlaying) {
+            unawaited(
+              handler.play().catchError((Object error, StackTrace stackTrace) {
+                _log.warning('Failed to start playback from iOS widget', error, stackTrace);
+              }),
+            );
+          } else {
+            await handler.pause();
+          }
+          await confirmation;
+        case 'previous':
+          final previousItemID = _liveCurrentQueueItem()?.baseItem.id.raw;
+          final confirmation = _waitForTrackChange(previousItemID);
+          await handler.skipToPrevious();
+          final confirmedItem = await confirmation;
+          if (confirmedItem != null) {
+            _bindItemProviders(confirmedItem.baseItem);
+            await _waitForArtworkPublication(confirmedItem.baseItem);
+          }
+        case 'next':
+          final previousItemID = _liveCurrentQueueItem()?.baseItem.id.raw;
+          final confirmation = _waitForTrackChange(previousItemID);
+          await handler.skipToNext();
+          final confirmedItem = await confirmation;
+          if (confirmedItem != null) {
+            _bindItemProviders(confirmedItem.baseItem);
+            await _waitForArtworkPublication(confirmedItem.baseItem);
+          }
+        case 'toggleFavorite':
+          await _toggleFavorite();
+        case 'setRating':
+          final stars = (arguments['rating'] as num?)?.toDouble();
+          if (stars == null || stars < 1 || stars > 5) {
+            throw ArgumentError.value(stars, 'rating', 'Widget rating must be between 1 and 5 stars');
+          }
+          await _writeRating(stars);
+        case 'clearRating':
+          await _writeRating(null);
+        default:
+          throw ArgumentError.value(action, 'action', 'Unknown iOS widget action');
+      }
+
+      // Track-change actions wait for the matching artwork publication above.
+      // Stream callbacks can still enqueue state writes while that happens, so
+      // drain the state tail before returning one final coherent snapshot to
+      // Swift. Swift persists it before AppIntent.perform() returns.
+      await _syncTail;
+      return _buildState();
+    } finally {
+      _widgetActionDepth--;
+    }
+  }
+
+  Future<PlaybackState?> _waitForPlaybackState(bool expectedPlaying) async {
+    final handler = _audioHandler;
+    if (handler == null) return null;
+    if (handler.playbackState.value.playing == expectedPlaying) {
+      return handler.playbackState.value;
+    }
+
+    try {
+      return await handler.playbackState
+          .firstWhere((state) => state.playing == expectedPlaying)
+          .timeout(_intentStateTimeout);
+    } on TimeoutException {
+      _log.warning(
+        'Timed out waiting for iOS widget playback state: '
+        'playing=$expectedPlaying',
+      );
+      return null;
+    }
+  }
+
+  Future<FinampQueueItem?> _waitForTrackChange(String? previousItemID) async {
+    if (previousItemID == null || !GetIt.instance.isRegistered<QueueService>()) {
+      return null;
+    }
+
+    try {
+      return await GetIt.instance<QueueService>()
+          .getCurrentTrackStream()
+          .firstWhere((queueItem) {
+            final itemID = queueItem?.baseItem.id.raw;
+            return itemID != null && itemID != previousItemID;
+          })
+          .timeout(_intentStateTimeout);
+    } on TimeoutException {
+      // Previous may intentionally seek to the beginning of the current track
+      // instead of changing tracks, and next may stay put at the end of a queue.
+      return _liveCurrentQueueItem();
+    }
+  }
+
+  Future<void> _toggleFavorite() async {
+    final item = _liveCurrentQueueItem()?.baseItem;
+    if (item == null) return;
+
+    final container = GetIt.instance<ProviderContainer>();
+    final provider = isFavoriteProvider(item);
+    final isFavorite = container.read(provider);
+
+    await container.read(provider.notifier).updateFavorite(!isFavorite);
+  }
+
+  Future<void> _writeRating(double? stars) async {
+    final item = _liveCurrentQueueItem()?.baseItem;
+    if (item == null) return;
+
+    if (FinampSettingsHelper.finampSettings.isOffline) {
+      throw StateError('Ratings cannot be changed while Finamp is offline');
+    }
+
+    final container = GetIt.instance<ProviderContainer>();
+    final provider = userRatingProvider(item);
+    final previous = container.read(provider);
+    final api = GetIt.instance<JellyfinApiHelper>();
+
+    try {
+      final userData = stars == null
+          ? await api.clearUserRating(item.id)
+          : await api.setUserRating(item.id, starsToRating(stars));
+      container.read(provider.notifier).state = userData.rating;
+    } catch (_) {
+      container.read(provider.notifier).state = previous;
+      rethrow;
+    }
+  }
+
+  Future<void> syncNow({bool? reload}) {
+    if (!Platform.isIOS) return Future<void>.value();
+
+    final shouldReload = reload ?? !_isHandlingWidgetAction;
+    final sync = _syncTail.then((_) => _syncNow(reload: shouldReload));
+    _syncTail = sync.catchError((Object error, StackTrace stackTrace) {
+      _log.warning('Failed to synchronize iOS widget state', error, stackTrace);
+    });
+    return sync;
+  }
+
+  bool _shouldPreserveStateDuringInitialQueueLoad() {
+    if (!GetIt.instance.isRegistered<QueueService>()) return true;
+
+    final queue = GetIt.instance<QueueService>().getQueue();
+    if (queue.currentTrack != null) return false;
+
+    return queue.saveState == SavedQueueState.preInit ||
+        queue.saveState == SavedQueueState.init ||
+        queue.saveState == SavedQueueState.loading;
+  }
+
+  Map<String, Object?> _buildState() {
+    final queueItem = _liveCurrentQueueItem();
+    final item = queueItem?.baseItem;
+    final currentMediaItem = queueItem?.item;
+    final handler = _audioHandler;
+    final container = GetIt.instance<ProviderContainer>();
+
+    final isFavorite = item == null ? false : container.read(isFavoriteProvider(item));
+    final jellyfinRating = item == null ? null : container.read(userRatingProvider(item));
+
+    return <String, Object?>{
+      'itemID': item?.id.raw,
+      'title': currentMediaItem?.title ?? 'Finamp',
+      'artist': currentMediaItem?.artist ?? '',
+      'album': currentMediaItem?.album ?? '',
+      'isPlaying': handler?.playbackState.value.playing ?? false,
+      'showStarRatings': FinampSettingsHelper.finampSettings.showStarRatings,
+      'isFavorite': isFavorite,
+      'starRating': jellyfinRating == null ? null : ratingToStarValue(jellyfinRating),
+    };
+  }
+
+  Future<void> _syncNow({required bool reload}) async {
+    if (_shouldPreserveStateDuringInitialQueueLoad()) return;
+
+    final state = _buildState();
+
+    try {
+      await _channel.invokeMethod<void>('updateState', <String, Object?>{...state, 'reload': reload});
+    } on PlatformException catch (error, stackTrace) {
+      _log.warning('Failed to update iOS widget state', error, stackTrace);
+    }
+  }
+
+  Future<void> dispose() async {
+    if (!_initialized) return;
+
+    _initialized = false;
+    _channel.setMethodCallHandler(null);
+    await _mediaItemSubscription?.cancel();
+    await _playbackStateSubscription?.cancel();
+    await _currentTrackSubscription?.cancel();
+    _showRatingsSubscription?.close();
+    _favoriteSubscription?.close();
+    _ratingSubscription?.close();
+
+    final artworkCompleter = _artworkReadyCompleter;
+    if (artworkCompleter != null && !artworkCompleter.isCompleted) {
+      artworkCompleter.complete();
+    }
+    _audioHandler = null;
+    _artworkTrackItemID = null;
+    _publishedArtworkItemID = null;
+    _artworkReadyCompleter = null;
+    _queueServiceBound = false;
+    _widgetActionDepth = 0;
+  }
+}

--- a/lib/services/jellyfin_api.chopper.dart
+++ b/lib/services/jellyfin_api.chopper.dart
@@ -834,6 +834,34 @@ final class _$JellyfinApi extends JellyfinApi {
   }
 
   @override
+  Future<dynamic> setUserRating({
+    required BaseItemId itemId,
+    required Map<String, dynamic> userData,
+  }) async {
+    final Uri $url = Uri.parse('/UserItems/${itemId}/UserData');
+    final $body = userData;
+    final Request $request = Request('POST', $url, client.baseUrl, body: $body);
+    final Response $response = await client.send<dynamic, dynamic>(
+      $request,
+      requestConverter: JsonConverter.requestFactory,
+      responseConverter: JsonConverter.responseFactory,
+    );
+    return $response.bodyOrThrow;
+  }
+
+  @override
+  Future<dynamic> clearUserRating({required BaseItemId itemId}) async {
+    final Uri $url = Uri.parse('/UserItems/${itemId}/Rating');
+    final Request $request = Request('DELETE', $url, client.baseUrl);
+    final Response $response = await client.send<dynamic, dynamic>(
+      $request,
+      requestConverter: JsonConverter.requestFactory,
+      responseConverter: JsonConverter.responseFactory,
+    );
+    return $response.bodyOrThrow;
+  }
+
+  @override
   Future<dynamic> getLyrics({required BaseItemId itemId}) async {
     final Uri $url = Uri.parse('/Audio/${itemId}/Lyrics');
     final Request $request = Request('GET', $url, client.baseUrl);

--- a/lib/services/jellyfin_api.dart
+++ b/lib/services/jellyfin_api.dart
@@ -558,6 +558,16 @@ abstract class JellyfinApi extends ChopperService {
     @Path() required BaseItemId itemId,
   });
 
+  /// Updates personal user data for an item.
+  @FactoryConverter(request: JsonConverter.requestFactory, response: JsonConverter.responseFactory)
+  @POST(path: "/UserItems/{itemId}/UserData")
+  Future<dynamic> setUserRating({@Path() required BaseItemId itemId, @Body() required Map<String, dynamic> userData});
+
+  /// Clears the personal numeric rating for an item.
+  @FactoryConverter(request: JsonConverter.requestFactory, response: JsonConverter.responseFactory)
+  @DELETE(path: "/UserItems/{itemId}/Rating")
+  Future<dynamic> clearUserRating({@Path() required BaseItemId itemId});
+
   /// Requests lyrics for a track.
   @FactoryConverter(request: JsonConverter.requestFactory, response: JsonConverter.responseFactory)
   @Get(path: "/Audio/{itemId}/Lyrics")

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -966,6 +966,28 @@ class JellyfinApiHelper {
     return UserItemDataDto.fromJson(response as Map<String, dynamic>);
   }
 
+  /// Sets the current user's personal Jellyfin rating for an item.
+  Future<UserItemDataDto> setUserRating(BaseItemId itemId, double rating) async {
+    assert(_verifyCallable());
+
+    if (rating < 0 || rating > 10) {
+      throw ArgumentError.value(rating, "rating", "Jellyfin ratings must be between 0 and 10");
+    }
+
+    final response = await jellyfinApi.setUserRating(itemId: itemId, userData: <String, dynamic>{"Rating": rating});
+
+    return UserItemDataDto.fromJson(response as Map<String, dynamic>);
+  }
+
+  /// Removes the current user's personal numeric rating for an item.
+  Future<UserItemDataDto> clearUserRating(BaseItemId itemId) async {
+    assert(_verifyCallable());
+
+    final response = await jellyfinApi.clearUserRating(itemId: itemId);
+
+    return UserItemDataDto.fromJson(response as Map<String, dynamic>);
+  }
+
   void addArtistToMixBuilderList(BaseItemDto item) {
     selectedMixArtists.add(item);
   }

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -12,8 +12,10 @@ import 'package:finamp/models/jellyfin_models.dart' as jellyfin_models;
 import 'package:finamp/services/current_track_metadata_provider.dart';
 import 'package:finamp/services/favorite_provider.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
+import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:finamp/services/playback_history_service.dart';
 import 'package:finamp/services/queue_service.dart';
+import 'package:finamp/services/user_rating_provider.dart';
 import 'package:finamp/services/radio_service_helper.dart' as RadioServiceHelper;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -300,6 +302,11 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
 
   MusicPlayerBackgroundTask() {
     _audioServiceBackgroundTaskLogger.info("Starting audio service");
+
+    GetIt.instance<ProviderContainer>().listen<bool>(
+      finampSettingsProvider.showStarRatings,
+      (_, _) => _handleStarRatingSettingChanged(),
+    );
 
     if (Platform.isWindows || Platform.isLinux) {
       _audioServiceBackgroundTaskLogger.info("Initializing media-kit for Windows/Linux");
@@ -1149,6 +1156,27 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
     return playbackState.add(event);
   }
 
+  void _handleStarRatingSettingChanged() {
+    final currentMediaItem = mediaItem.valueOrNull;
+
+    if (currentMediaItem?.extras?["itemJson"] != null) {
+      final currentItem = jellyfin_models.BaseItemDto.fromJson(
+        currentMediaItem!.extras!["itemJson"] as Map<String, dynamic>,
+      );
+      final currentRating = GetIt.instance<ProviderContainer>().read(userRatingProvider(currentItem));
+
+      mediaItem.add(
+        currentMediaItem.copyWith(
+          rating: FinampSettingsHelper.finampSettings.showStarRatings
+              ? Rating.newHeartRating((currentRating ?? 0) >= 10.0)
+              : null,
+        ),
+      );
+    }
+
+    unawaited(refreshPlaybackStateAndMediaNotification());
+  }
+
   // triggers when skipping to specific item in android auto queue
   @override
   Future<void> skipToQueueItem(int index) async {
@@ -1274,9 +1302,15 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
         if (FinampSettingsHelper.finampSettings.showStopButtonOnMediaNotification)
           MediaControl.stop.copyWith(androidIcon: "drawable/baseline_stop_24"),
       ],
-      systemActions: FinampSettingsHelper.finampSettings.showSeekControlsOnMediaNotification
-          ? const {MediaAction.seek, MediaAction.seekForward, MediaAction.seekBackward}
-          : {},
+      systemActions: {
+        if (FinampSettingsHelper.finampSettings.showSeekControlsOnMediaNotification) ...{
+          MediaAction.seek,
+          MediaAction.seekForward,
+          MediaAction.seekBackward,
+        },
+        if (FinampSettingsHelper.finampSettings.showStarRatings && !FinampSettingsHelper.finampSettings.isOffline)
+          MediaAction.setRating,
+      },
       androidCompactActionIndices: const [0, 1, 2],
       processingState: const {
         ProcessingState.idle: AudioProcessingState.idle,
@@ -1466,12 +1500,44 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
     bool isFavorite = currentItem.userData?.isFavorite ?? false;
     switch (rating.getRatingStyle()) {
       case RatingStyle.heart:
-        if (rating.hasHeart() && !isFavorite) {
-          // add favorite
-          await toggleFavoriteStatusOfCurrentTrack();
-        } else if (!rating.hasHeart() && isFavorite) {
-          // remove favorite
-          await toggleFavoriteStatusOfCurrentTrack();
+        if (!FinampSettingsHelper.finampSettings.showStarRatings) {
+          if (rating.hasHeart() && !isFavorite) {
+            await toggleFavoriteStatusOfCurrentTrack();
+          } else if (!rating.hasHeart() && isFavorite) {
+            await toggleFavoriteStatusOfCurrentTrack();
+          }
+          break;
+        }
+
+        if (FinampSettingsHelper.finampSettings.isOffline) {
+          return;
+        }
+
+        final container = GetIt.instance<ProviderContainer>();
+        final provider = userRatingProvider(currentItem);
+        final previousRating = container.read(provider);
+
+        try {
+          final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
+          final userData = rating.hasHeart()
+              ? await jellyfinApiHelper.setUserRating(currentItem.id, 10.0)
+              : await jellyfinApiHelper.clearUserRating(currentItem.id);
+
+          container.read(provider.notifier).state = userData.rating;
+
+          final currentMediaItem = mediaItem.valueOrNull;
+          if (currentMediaItem != null) {
+            mediaItem.add(currentMediaItem.copyWith(rating: Rating.newHeartRating((userData.rating ?? 0) >= 10.0)));
+          }
+
+          _audioServiceBackgroundTaskLogger.fine("Updated personal rating from system control: ${userData.rating}");
+        } catch (error, stackTrace) {
+          container.read(provider.notifier).state = previousRating;
+          _audioServiceBackgroundTaskLogger.warning(
+            "Failed to update personal rating from system control",
+            error,
+            stackTrace,
+          );
         }
         break;
       case RatingStyle.thumbUpDown:

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -30,6 +30,7 @@ import 'package:rxdart/rxdart.dart';
 import 'android_auto_helper.dart';
 import 'finamp_settings_helper.dart';
 import 'ios_helpers.dart';
+import 'ios_widget_service.dart';
 import 'metadata_provider.dart';
 
 enum FadeDirection { fadeIn, fadeOut, none }
@@ -307,6 +308,8 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
       finampSettingsProvider.showStarRatings,
       (_, _) => _handleStarRatingSettingChanged(),
     );
+
+    unawaited(IosWidgetService.instance.initialize(audioHandler: this));
 
     if (Platform.isWindows || Platform.isLinux) {
       _audioServiceBackgroundTaskLogger.info("Initializing media-kit for Windows/Linux");

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -21,6 +21,7 @@ import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:finamp/services/music_player_background_task.dart';
 import 'package:finamp/services/playback_history_service.dart';
 import 'package:finamp/services/radio_service_helper.dart';
+import 'package:finamp/services/user_rating_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
@@ -181,6 +182,7 @@ class QueueService {
   }
 
   ProviderSubscription<AlbumImageInfo>? _latestAlbumImage;
+  ProviderSubscription<double?>? _currentRatingSubscription;
 
   void _buildQueueFromNativePlayerQueue({bool logUpdate = true, int? indexOverride}) {
     final playbackHistoryService = GetIt.instance<PlaybackHistoryService>();
@@ -280,8 +282,28 @@ class QueueService {
     refreshQueueStream();
     _currentTrackStream.add(_currentTrack);
     var currentMediaItem = _currentTrack?.item;
+
+    _currentRatingSubscription?.close();
+    _currentRatingSubscription = null;
+
     if (currentMediaItem != null) {
       final item = jellyfin_models.BaseItemDto.fromJson(currentMediaItem.extras!["itemJson"] as Map<String, dynamic>);
+
+      void updateRating(double? rating) {
+        currentMediaItem = currentMediaItem?.copyWith(
+          rating: FinampSettingsHelper.finampSettings.showStarRatings
+              ? Rating.newHeartRating((rating ?? 0) >= 10.0)
+              : null,
+        );
+        _audioHandler.mediaItem.add(currentMediaItem);
+      }
+
+      _currentRatingSubscription = _providers.listen<double?>(
+        userRatingProvider(item),
+        (_, rating) => updateRating(rating),
+        fireImmediately: true,
+      );
+
       final artRequest = AlbumImageRequest(item: item);
 
       void updateMediaItem(AlbumImageInfo latest, bool force) async {
@@ -1504,6 +1526,9 @@ class QueueService {
       album: item.album,
       artist: item.artists?.sortedBy((e) => e).join(", ") ?? item.albumArtist,
       title: item.name ?? "unknown",
+      rating: FinampSettingsHelper.finampSettings.showStarRatings
+          ? Rating.newHeartRating((item.userData?.rating ?? 0) >= 10.0)
+          : null,
       extras: {
         //!!! this ID has to be consistent across the transcoding URL and the playback reporting status, otherwise the server won't show that we're transcoding
         "playSessionId": uuid.v4(),

--- a/lib/services/user_rating_provider.dart
+++ b/lib/services/user_rating_provider.dart
@@ -1,0 +1,55 @@
+import 'package:finamp/components/global_snackbar.dart';
+import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/models/jellyfin_models.dart';
+import 'package:finamp/services/feedback_helper.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:finamp/services/jellyfin_api_helper.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:get_it/get_it.dart';
+
+final userRatingProvider = StateProvider.autoDispose.family<double?, BaseItemDto>((ref, item) => item.userData?.rating);
+
+final userRatingUpdatingProvider = StateProvider.autoDispose.family<bool, BaseItemId>((ref, itemId) => false);
+
+double ratingToStarValue(double? rating) {
+  if (rating == null) return 0;
+  return (rating / 2).clamp(0.0, 5.0);
+}
+
+int ratingToStars(double? rating) => ratingToStarValue(rating).round();
+
+double starsToRating(num stars) => stars.clamp(0.5, 5.0).toDouble() * 2.0;
+
+Future<void> setUserRating(WidgetRef ref, BaseItemDto item, num? stars) async {
+  if (FinampSettingsHelper.finampSettings.isOffline) {
+    FeedbackHelper.feedback(FeedbackType.error);
+    GlobalSnackbar.message((context) => AppLocalizations.of(context)!.notAvailableInOfflineMode);
+    return;
+  }
+
+  final updatingProvider = userRatingUpdatingProvider(item.id);
+  if (ref.read(updatingProvider)) return;
+
+  final provider = userRatingProvider(item);
+  final oldRating = ref.read(provider);
+  final newRating = stars == null || stars <= 0 ? null : starsToRating(stars);
+
+  ref.read(updatingProvider.notifier).state = true;
+  ref.read(provider.notifier).state = newRating;
+
+  try {
+    final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
+    final userData = newRating == null
+        ? await jellyfinApiHelper.clearUserRating(item.id)
+        : await jellyfinApiHelper.setUserRating(item.id, newRating);
+
+    ref.read(provider.notifier).state = userData.rating;
+    FeedbackHelper.feedback(FeedbackType.selection);
+  } catch (error) {
+    ref.read(provider.notifier).state = oldRating;
+    FeedbackHelper.feedback(FeedbackType.error);
+    GlobalSnackbar.error(error);
+  } finally {
+    ref.read(updatingProvider.notifier).state = false;
+  }
+}

--- a/test/services/user_rating_provider_test.dart
+++ b/test/services/user_rating_provider_test.dart
@@ -1,0 +1,67 @@
+import 'package:finamp/services/user_rating_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ratingToStars', () {
+    test('maps Jellyfin 0-10 ratings to five stars', () {
+      expect(ratingToStars(null), 0);
+      expect(ratingToStars(0), 0);
+      expect(ratingToStars(2), 1);
+      expect(ratingToStars(4), 2);
+      expect(ratingToStars(6), 3);
+      expect(ratingToStars(8), 4);
+      expect(ratingToStars(10), 5);
+    });
+
+    test('rounds intermediate Jellyfin ratings to the nearest star', () {
+      expect(ratingToStars(1), 1);
+      expect(ratingToStars(3), 2);
+      expect(ratingToStars(5), 3);
+      expect(ratingToStars(7), 4);
+      expect(ratingToStars(9), 5);
+    });
+
+    test('clamps out-of-range input defensively', () {
+      expect(ratingToStars(-1), 0);
+      expect(ratingToStars(11), 5);
+    });
+  });
+
+  group('ratingToStarValue', () {
+    test('preserves half-star values from Jellyfin', () {
+      expect(ratingToStarValue(1), 0.5);
+      expect(ratingToStarValue(3), 1.5);
+      expect(ratingToStarValue(5), 2.5);
+      expect(ratingToStarValue(7), 3.5);
+      expect(ratingToStarValue(9), 4.5);
+    });
+
+    test('clamps out-of-range values', () {
+      expect(ratingToStarValue(-1), 0.0);
+      expect(ratingToStarValue(11), 5.0);
+    });
+  });
+
+  group('starsToRating', () {
+    test('maps five stars to Jellyfin 0-10 rating values', () {
+      expect(starsToRating(1), 2.0);
+      expect(starsToRating(2), 4.0);
+      expect(starsToRating(3), 6.0);
+      expect(starsToRating(4), 8.0);
+      expect(starsToRating(5), 10.0);
+    });
+
+    test('maps half stars to odd Jellyfin rating values', () {
+      expect(starsToRating(0.5), 1.0);
+      expect(starsToRating(1.5), 3.0);
+      expect(starsToRating(2.5), 5.0);
+      expect(starsToRating(3.5), 7.0);
+      expect(starsToRating(4.5), 9.0);
+    });
+
+    test('clamps invalid star counts defensively', () {
+      expect(starsToRating(0), 1.0);
+      expect(starsToRating(6), 10.0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a native WidgetKit Now Playing widget for iOS.

The widget supports small, medium, and large sizes and mirrors Finamp's current playback state, artwork, metadata, favorite state, and optional star ratings.

Playback controls use App Intents and support:

- Previous track
- Play / Pause
- Next track

On iOS 27 builds compiled with Swift 6.4 or newer, the widget also supports interactive metadata actions:

- Toggle favorite
- Set star rating
- Clear star rating

On older toolchains or older iOS versions, rating/favorite state remains read-only.

## Related issues

Addresses #156.

This also covers the iOS widget request previously discussed in #579, which was closed as a duplicate of #156.

The implementation intentionally only addresses the iOS side of #156; Android widget support remains outside the scope of this PR.

## Architecture

The widget does not connect to Jellyfin directly.

Finamp's main process publishes a sanitized state snapshot and downsampled artwork into an App Group container. The WidgetKit extension only reads that state.

Shared widget state contains:

- item ID
- title
- artist
- album
- playback state
- favorite state
- star rating
- cover revision

No Jellyfin credentials or authentication tokens are shared with the widget extension.

Widget actions are routed back through the existing Finamp services instead of implementing a second playback or networking stack inside the extension.

## Compatibility

- Main app deployment target remains iOS 15
- Widget extension requires iOS 17
- Builds successfully with Xcode 26.6 stable
- Builds successfully with Xcode 27 beta
- iOS 27-only App Intent process targeting is guarded at compile time so stable Xcode releases can continue to build the project
- Widget version and build number inherit Flutter's `FLUTTER_BUILD_NAME` and `FLUTTER_BUILD_NUMBER`

Verified release bundle versions:

Runner: 0.9.25 (126)
Widget: 0.9.25 (126)

## Dependency

This PR depends on #1736 for optional Jellyfin star ratings.

Until #1736 is merged, its rating-related changes may also appear in this PR's diff. They are not duplicated as part of the widget implementation and can be rebased away once #1736 lands.

## Apple Developer configuration

The following App Group must be registered in the Apple Developer account and enabled for both the main app and widget extension:

`group.com.unicornsonlsd.finamp-ios.widget`

## Testing

Tested with:

- Xcode 26.6 stable
- Xcode 27 beta
- iOS 27 device
- Release build with codesigning disabled

Build command:

`flutter build ios --release --no-pub --no-codesign`

## AI assistance

This implementation was created with assistance from AI. The code was manually reviewed, tested on device, and verified with both stable and beta Xcode toolchains.