### PR TITLE
fix starting queue from nth occurrence of a track in playlist starts queue from 1st occurrence, where n > 1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1773471952,
-        "narHash": "sha256-kIRggXyT8RzijtfvyRIzj+zIDWM2fnCp8t0X4BkkTVc=",
+        "lastModified": 1788865058,
+        "narHash": "sha256-ZkvwEHlSa46BkODMEwHCEh9hlUC2igneJ+noEUn9ww4=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "a1b770adbc3f6c27485d03b90462ec414d4e1ce5",
+        "rev": "9efa138447c5773995d98d9aafa9eba4982aceab",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773282481,
-        "narHash": "sha256-b/GV2ysM8mKHhinse2wz+uP37epUrSE+sAKXy/xvBY4=",
+        "lastModified": 1788752844,
+        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe416aaedd397cacb33a610b33d60ff2b431b127",
+        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1773326183,
-        "narHash": "sha256-tj3piRd9RnnP36HwHmQD4O4XZeowsH/rvMeyp9Pmot0=",
+        "lastModified": 1788794694,
+        "narHash": "sha256-FROpcpM2ELawfxhW8cWuz8m3dp/0EFAFCiK+AbNw95w=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "6254616e97f358e67b70dfc0463687f5f7911c1a",
+        "rev": "48d839420745124e85140234ce783ccd90dab24e",
         "type": "github"
       },
       "original": {

--- a/lib/components/AlbumScreen/album_screen_content.dart
+++ b/lib/components/AlbumScreen/album_screen_content.dart
@@ -290,9 +290,16 @@ class _TracksSliverListState extends ConsumerState<TracksSliverList> {
         // When user selects track from disc other than first, index number is
         // incorrect and track with the same index on first disc is played instead.
         // Adding this offset ensures playback starts for nth track on correct disc.
-        final indexOffset = widget.childrenForQueue.indexWhere(
-          (element) => element.id == widget.childrenForList[index].id,
-        );
+        final currentId = widget.childrenForList[index].id;
+        final dupesBefore = widget.childrenForList.take(index).where((element) => element.id == currentId).length;
+        final indexOffset =
+            widget.childrenForQueue.indexed
+                .where((element) => element.$2.id == currentId)
+                // assuming duplicates are only possible when childrenForQueue is a sparse sublist of childrenForList
+                .skip(dupesBefore)
+                .firstOrNull // it is null for unplayable tracks
+                ?.$1 ??
+            -1;
 
         final BaseItemDto item = widget.childrenForList[index];
 

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -4468,6 +4468,7 @@ enum FinampQuickActions {
   surpriseMe(true),
   @HiveField(9)
   playSpecificItem(true);
+
   // ID 10 moved upwards for more sensible user-facing ordering
   //TODO support album/artist shuffle (requires queue support)
 


### PR DESCRIPTION
## Changes

TracksSliverList searches first instance of track in prepared queue, even if user taps later instances, then starts queue there. This means that for a playlist of:

1. Track A
2. Track B
3. Track C
4. Track B
5. Track D

Tapping on item 4 starts queue from item 2, which is not correct.

This PR fixes that by assuming duplicates are only possible in this branch since the other branch is guarded against playlists:

https://github.com/finamp-app/finamp/blob/e8302a2e02fc942b7c0059cdff25529791d481f1/lib/components/AlbumScreen/album_screen_content.dart#L219-L227

Then, due to the fact queueChildren is a sparse sublist of displayChildren, it's possible to count duplicates in displayChildren preceding tapped item; then, assuming tracks with the same id are either all playable or not (i.e. for all tracks it is either playable or not, see law of excluded middle :P), skipping the same number of duplicates in queueChildren means taking a track at exactly the same position. When it's zero (no duplicates, e.g. an album), it's the same behavior, and when current track is not playable it falls back to -1 as a workaround to the fact it is calculated eagerly even for unplayable tracks.

There is another approach: pass concatenated list of previous `queueForList`s (which would still be displayChildren for the branch mentioned above and accumulated list for preceding album with discs branch) to be used to calculate `dupesBefore`. It's only better if albums can have duplicates, too, which isn't possible in Jellyfin I hope.

The only problem with all of this elegance is the fact flutter let me down and doesn't build Finamp due to stdlib problems, and I can't update it at the moment. This was planned to be 20-minute adventure which went wrong for more than 1 hour so idk. I hope CI creates android artifact which I can test myself later.

## Todo before merging

- [x] Test it
- [x] ~~`.where(...).length` can possibly be replaced with some kind of `count(...)` but I didn't find any~~
- [ ] (Possible follow-up) reduce O(n^2) to O(n) by delaying index calculation into a lambda since it's only required on tap; quadratic complexity is not introduced by this PR

---

[`dart format .` let me down too](https://github.com/finamp-app/finamp/actions/runs/34155531899/job/101846449862?pr=1761). What a day. It changes nothing on my system.